### PR TITLE
Update Quarkus Runtime to 1.4.2.Final (#71)

### DIFF
--- a/src/main/resources/quarkus.xml
+++ b/src/main/resources/quarkus.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <artifacts>
-    <artifact version="0.17.0" name="Quarkus">
-        <item name="quarkus-core-0.17.0.jar" md5=""
-              url="http://central.maven.org/maven2/io/quarkus/quarkus-core/0.17.0/quarkus-core-0.17.0.jar">
+    <artifact version="1.4.2.Final" name="Quarkus">
+        <item name="quarkus-core-1.4.2.Final.jar" md5=""
+              url="https://repo1.maven.org/maven2/io/quarkus/quarkus-core/1.4.2.Final/quarkus-core-1.4.2.Final.jar">
             <required-class fqn="io.quarkus.runtime.Quarkus"/>
         </item>
     </artifact>


### PR DESCRIPTION
Update Quarkus Runtime to 1.4.2.Final (#71)

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>
Tested on localhost.

Please review @jeffmaury 

**Displayed value:**
<img width="702" alt="81204851-224f2780-8fca-11ea-91b7-8591bc84e59f" src="https://user-images.githubusercontent.com/43820055/81205728-64c53400-8fcb-11ea-8560-6262f2569fc6.png">

**Download works:**
<img width="270" alt="Snímek obrazovky 2020-05-06 v 18 56 29" src="https://user-images.githubusercontent.com/43820055/81205693-5aa33580-8fcb-11ea-8d69-ffdac18099b3.png">
