### PR TITLE
Fix the errors in the javadoc

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/search/IPropertiesProvider.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/search/IPropertiesProvider.java
@@ -16,7 +16,7 @@ import com.intellij.util.Query;
 /**
  * Properties provider API.
  *
- * @see <a ref="https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/IPropertiesProvider.java">https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/IPropertiesProvider.java</a>
+ * @see <a href="https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/IPropertiesProvider.java">https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/IPropertiesProvider.java</a>
  */
 public interface IPropertiesProvider {
 	public static final ExtensionPointName<IPropertiesProvider> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.propertiesProvider");

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/search/SearchContext.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/search/SearchContext.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * @see <a href="https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/SearchContext.java>https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/SearchContext.java</a>
+ * @see <a href="https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/SearchContext.java">https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/SearchContext.java</a>
  */
 public class SearchContext {
 


### PR DESCRIPTION
Fix the errors in the javadoc

Fixes #102

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

Please review @jeffmaury 

**Now the javadoc gradle task is finally successful:**

```
23:57:10: Executing task 'javadoc'...

> Task :copyDeps UP-TO-DATE
> Task :compileJava UP-TO-DATE
> Task :patchPluginXml UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :instrumentCode UP-TO-DATE
> Task :postInstrumentCode
> Task :javadoc UP-TO-DATE

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 565ms
7 actionable tasks: 1 executed, 6 up-to-date
23:57:11: Task execution finished 'javadoc'.
```