### PR TITLE
Update the plugin runtime to version 1.5.2.Final

### DIFF
--- a/projects/gradle/config-properties/gradle.properties
+++ b/projects/gradle/config-properties/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 #Wed Jun 03 05:57:10 UTC 2020
-quarkusPluginVersion=1.5.0.Final
+quarkusPluginVersion=1.5.2.Final
 quarkusPlatformArtifactId=quarkus-universe-bom
 quarkusPlatformGroupId=io.quarkus
-quarkusPlatformVersion=1.5.0.Final
+quarkusPlatformVersion=1.5.2.Final

--- a/projects/gradle/config-properties/src/main/resources/META-INF/resources/index.html
+++ b/projects/gradle/config-properties/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: config-properties</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.5.0.Final</li>
+                <li>Quarkus Version: 1.5.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/projects/gradle/microprofile-context-propagation/gradle.properties
+++ b/projects/gradle/microprofile-context-propagation/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 #Thu May 28 15:41:02 UTC 2020
-quarkusPluginVersion=1.5.0.Final
+quarkusPluginVersion=1.5.2.Final
 quarkusPlatformArtifactId=quarkus-universe-bom
 quarkusPlatformGroupId=io.quarkus
-quarkusPlatformVersion=1.5.0.Final
+quarkusPlatformVersion=1.5.2.Final

--- a/projects/gradle/microprofile-context-propagation/src/main/resources/META-INF/resources/index.html
+++ b/projects/gradle/microprofile-context-propagation/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-context-propagation</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.5.0.Final</li>
+                <li>Quarkus Version: 1.5.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/projects/gradle/microprofile-lra/gradle.properties
+++ b/projects/gradle/microprofile-lra/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 #Thu May 28 16:02:35 UTC 2020
-quarkusPluginVersion=1.5.0.Final
+quarkusPluginVersion=1.5.2.Final
 quarkusPlatformArtifactId=quarkus-universe-bom
 quarkusPlatformGroupId=io.quarkus
-quarkusPlatformVersion=1.5.0.Final
+quarkusPlatformVersion=1.5.2.Final

--- a/projects/gradle/microprofile-lra/src/main/resources/META-INF/resources/index.html
+++ b/projects/gradle/microprofile-lra/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-lra</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.5.0.Final</li>
+                <li>Quarkus Version: 1.5.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/projects/gradle/microprofile-openapi/gradle.properties
+++ b/projects/gradle/microprofile-openapi/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 #Thu May 28 16:19:07 UTC 2020
-quarkusPluginVersion=1.5.0.Final
+quarkusPluginVersion=1.5.2.Final
 quarkusPlatformArtifactId=quarkus-universe-bom
 quarkusPlatformGroupId=io.quarkus
-quarkusPlatformVersion=1.5.0.Final
+quarkusPlatformVersion=1.5.2.Final

--- a/projects/gradle/microprofile-openapi/src/main/resources/META-INF/resources/index.html
+++ b/projects/gradle/microprofile-openapi/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: microprofile-openapi</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.5.0.Final</li>
+                <li>Quarkus Version: 1.5.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/projects/gradle/using-vertx/gradle.properties
+++ b/projects/gradle/using-vertx/gradle.properties
@@ -1,6 +1,6 @@
 #Gradle properties
 #Tue Jun 02 18:03:01 UTC 2020
-quarkusPluginVersion=1.5.0.Final
+quarkusPluginVersion=1.5.2.Final
 quarkusPlatformArtifactId=quarkus-universe-bom
 quarkusPlatformGroupId=io.quarkus
-quarkusPlatformVersion=1.5.0.Final
+quarkusPlatformVersion=1.5.2.Final

--- a/projects/gradle/using-vertx/src/main/resources/META-INF/resources/index.html
+++ b/projects/gradle/using-vertx/src/main/resources/META-INF/resources/index.html
@@ -133,7 +133,7 @@
                 <li>GroupId: org.acme</li>
                 <li>ArtifactId: using-vertx</li>
                 <li>Version: 1.0.0-SNAPSHOT</li>
-                <li>Quarkus Version: 1.5.0.Final</li>
+                <li>Quarkus Version: 1.5.2.Final</li>
             </ul>
         </div>
         <div class="right-section">

--- a/src/main/resources/quarkus.xml
+++ b/src/main/resources/quarkus.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <artifacts>
-    <artifact version="1.5.0.Final" name="Quarkus">
-        <item name="quarkus-core-1.5.0.Final.jar" md5=""
-              url="https://repo1.maven.org/maven2/io/quarkus/quarkus-core/1.5.0.Final/quarkus-core-1.5.0.Final.jar">
+    <artifact version="1.5.2.Final" name="Quarkus">
+        <item name="quarkus-core-1.5.2.Final.jar" md5=""
+              url="https://repo1.maven.org/maven2/io/quarkus/quarkus-core/1.5.2.Final/quarkus-core-1.5.2.Final.jar">
             <required-class fqn="io.quarkus.runtime.Quarkus"/>
         </item>
     </artifact>


### PR DESCRIPTION
Fixes #144

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

According to my manager @psrna we should deliver the newest version of runtime to our customers. I  upgraded the runtime to the newest version - 1.5.1.Final. If we merge this PR, we can make release of this plugin with newest runtime next week. Please review @jeffmaury 