### PR TITLE
Add default case for switch statements

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/search/PropertiesManager.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/search/PropertiesManager.java
@@ -138,6 +138,10 @@ public class PropertiesManager {
                 case dependencies:
                     searchScope = searchScope.union(module.getModuleWithLibrariesScope());
                     break;
+               //missing default case
+                default:
+                    // add default case
+                   break;               
             }
         }
         return searchScope;


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html