### PR TITLE
Add default case for switch statements

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/javadoc/JavaDoc2HTMLTextReader.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/javadoc/JavaDoc2HTMLTextReader.java
@@ -74,6 +74,11 @@ public class JavaDoc2HTMLTextReader extends SubstitutionTextReader {
                         case '\n':
                         case '\r':
                             return c;
+                       //missing default case
+                        default:
+                            // add default case
+                            break;
+      
                     }
                     if (index <= 0) {
                         return c;


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html