### PR TITLE
Update to fix HTTP endpoints

### DIFF
--- a/intellij-community/plugins/gradle/tooling-extension-impl/testSources/org/jetbrains/plugins/gradle/tooling/builder/AbstractModelBuilderTest.java
+++ b/intellij-community/plugins/gradle/tooling-extension-impl/testSources/org/jetbrains/plugins/gradle/tooling/builder/AbstractModelBuilderTest.java
@@ -243,11 +243,11 @@ public abstract class AbstractModelBuilderTest {
     private static final String RELEASE_REPOSITORY_ENV = "GRADLE_RELEASE_REPOSITORY";
     private static final String SNAPSHOT_REPOSITORY_ENV = "GRADLE_SNAPSHOT_REPOSITORY";
     private static final String INTELLIJ_LABS_GRADLE_RELEASE_MIRROR =
-      "http://services.gradle.org-mirror.labs.intellij.net/distributions";
+      "https://services.gradle.org-mirror.labs.intellij.net/distributions";
     private static final String INTELLIJ_LABS_GRADLE_SNAPSHOT_MIRROR =
-      "http://services.gradle.org-mirror.labs.intellij.net/distributions-snapshots";
-    private static final String GRADLE_RELEASE_REPO = "http://services.gradle.org/distributions";
-    private static final String GRADLE_SNAPSHOT_REPO = "http://services.gradle.org/distributions-snapshots";
+      "https://services.gradle.org-mirror.labs.intellij.net/distributions-snapshots";
+    private static final String GRADLE_RELEASE_REPO = "https://services.gradle.org/distributions";
+    private static final String GRADLE_SNAPSHOT_REPO = "https://services.gradle.org/distributions-snapshots";
 
     @NotNull private final String myReleaseRepoUrl;
     @NotNull private final String mySnapshotRepoUrl;


### PR DESCRIPTION
Some of the endpoints are still using HTTP that is insecure ... replaced with secure HTTP (HTTP with SSL/TLS) that exists.  

Details:

I found instances where the HTTP protocol is used instead of HTTPS (HTTP with TLS). According to the Common Weakness Enumeration organization this is a security weakness (https://cwe.mitre.org/data/definitions/319.html).