### PR TITLE
Fix the bug that makes all UI tests fail to start when starting the IDE takes longer

### DIFF
--- a/src/it/java/org/jboss/tools/intellij/quarkus/BasicTests.java
+++ b/src/it/java/org/jboss/tools/intellij/quarkus/BasicTests.java
@@ -32,6 +32,7 @@ public class BasicTests {
 
     @BeforeAll
     public static void connect() throws InterruptedException {
+        GlobalUtils.waitUntilIntelliJStarts();
         robot = new RemoteRobot("http://127.0.0.1:8082");
         for (int i = 0; i < 60; i++) {
             try {

--- a/src/it/java/org/jboss/tools/intellij/quarkus/utils/GlobalUtils.java
+++ b/src/it/java/org/jboss/tools/intellij/quarkus/utils/GlobalUtils.java
@@ -21,6 +21,9 @@ import org.jboss.tools.intellij.quarkus.fixtures.mainIdeWindow.IdeStatusBarFixtu
 
 import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
 import java.time.Duration;
 
 import static com.intellij.remoterobot.search.locators.Locators.byXpath;
@@ -181,5 +184,25 @@ public class GlobalUtils {
             // the list with accessible name 'Recent Projects' is not available -> 0 links in the 'Welcome to IntelliJ IDEA' dialog
             return 0;
         }
+    }
+
+    public static void waitUntilIntelliJStarts() {
+        waitFor(Duration.ofSeconds(300), Duration.ofSeconds(3), "The IntelliJ Idea did not start in 5 minutes.", () -> isIntelliJUIVisible());
+    }
+
+    private static boolean isIntelliJUIVisible() {
+        return isHostOnIpAndPortAccessible("127.0.0.1", 8082);
+    }
+
+    private static boolean isHostOnIpAndPortAccessible(String ip, int port) {
+        SocketAddress sockaddr = new InetSocketAddress(ip, port);
+        Socket socket = new Socket();
+
+        try {
+            socket.connect(sockaddr, 10000);
+        } catch (IOException IOException) {
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Fix the bug that makes all UI tests fail to start when starting the IDE takes longer

Fixes #269

Signed-off-by: Zbynek Cervinka <zcervink@redhat.com>

Please review @jrichter1 @jeffmaury 

@jrichter1 we have discussed this issue before - is this the solution you were talking about? Do you think that the timeout 5 minutes is acceptable for downloading any supported IntelliJ version and start the IDE on our infrastructure?