### PR TITLE
fix: java.lang.IllegalArgumentException: Argument for @NotNull parame…

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/core/ls/PsiUtilsLSImpl.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/core/ls/PsiUtilsLSImpl.java
@@ -84,11 +84,8 @@ public class PsiUtilsLSImpl implements IPsiUtils {
 
     @Override
     public Module getModule(VirtualFile file) {
-        for (Project project : ProjectManager.getInstance().getOpenProjects()) {
-            Module module = ProjectFileIndex.getInstance(project).getModuleForFile(file);
-            if (module != null) {
-                return module;
-            }
+        if (file != null) {
+            return ProjectFileIndex.getInstance(project).getModuleForFile(file);
         }
         return null;
     }


### PR DESCRIPTION
…ter 'file' of com/intellij/openapi/roots/impl/ProjectFileIndexImpl.getModuleForFile must not be null

Fixes #590

Signed-off-by: Jeff MAURY <jmaury@redhat.com>