### PR TITLE
fix: java.lang.Throwable: Do not perform a synchronous refresh under …

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/QuarkusProjectService.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/QuarkusProjectService.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.quarkus;
 
+import com.intellij.json.JsonFileType;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.module.Module;
@@ -20,7 +21,6 @@ import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
 import com.intellij.openapi.roots.libraries.LibraryTablesRegistrar;
-import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
@@ -29,22 +29,22 @@ import com.intellij.openapi.vfs.newvfs.events.VFileContentChangeEvent;
 import com.intellij.openapi.vfs.newvfs.events.VFileCreateEvent;
 import com.intellij.openapi.vfs.newvfs.events.VFileDeleteEvent;
 import com.intellij.openapi.vfs.newvfs.events.VFileEvent;
+import com.intellij.testFramework.LightVirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
 import com.intellij.util.messages.Topic;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.PropertiesManager;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.lsp4mp.commons.ClasspathKind;
 import org.eclipse.lsp4mp.commons.DocumentFormat;
 import org.eclipse.lsp4mp.commons.MicroProfileProjectInfo;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;
 import org.eclipse.lsp4mp.utils.JSONSchemaUtils;
-import org.apache.commons.lang3.tuple.MutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
@@ -136,10 +136,7 @@ public class QuarkusProjectService implements LibraryTable.Listener, BulkFileLis
     }
 
     private static VirtualFile createJSONSchemaFile(String name) throws IOException {
-        File file = new File(System.getProperty("java.io.tmpdir"), name + "-schema.json");
-        file.createNewFile();
-        file.deleteOnExit();
-        return LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
+        return new LightVirtualFile(name + "-schema.json", JsonFileType.INSTANCE, "");
     }
 
 


### PR DESCRIPTION
…read lock (except from EDT) - causes deadlocks if there are events to fire

Fixes #589

Signed-off-by: Jeff MAURY <jmaury@redhat.com>