### PR TITLE
fix: CannotReadException in IntelliJ IDEA 2022.3.1 (Ultimate Edition)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp4ij/IndexAwareLanguageClient.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp4ij/IndexAwareLanguageClient.java
@@ -96,7 +96,7 @@ public class IndexAwareLanguageClient extends LanguageClientImpl {
       try {
         future.complete(function.apply(indicator));
         done = true;
-      } catch (IndexNotReadyException e) {
+      } catch (IndexNotReadyException | ReadAction.CannotReadException e) {
       } catch (Throwable t) {
         future.completeExceptionally(t);
         done = true;


### PR DESCRIPTION
Fixes #729