### PR TITLE
java.lang.NullPointerException: Cannot invoke "java.util.concurrent.CompletableFuture.thenRun(java.lang.Runnable)" because "this.initializeFuture" is null

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp4ij/LanguageServerWrapper.java
@@ -323,7 +323,11 @@ public class LanguageServerWrapper {
             initializeFuture = languageServer.initialize(initParams).thenAccept(res -> {
                 serverCapabilities = res.getCapabilities();
                 this.initiallySupportsWorkspaceFolders = supportsWorkspaceFolders(serverCapabilities);
-            }).thenRun(() -> {
+            });
+            initializeFuture.thenRun(() -> {
+            	// Here we call languageServer.initialized which will send to this IJ LSP client several 'client/registerCapability' 
+            	// which will call the private method registerCapability(RegistrationParams params)
+            	// See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#client_registerCapability
                 this.languageServer.initialized(new InitializedParams());
             });
 


### PR DESCRIPTION
java.lang.NullPointerException: Cannot invoke "java.util.concurrent.CompletableFuture.thenRun(java.lang.Runnable)" because "this.initializeFuture" is null

Fixes #748

The code https://github.com/redhat-developer/intellij-quarkus/blob/afa96c3cc72fda4d418c411e950994920372d123/src/main/java/com/redhat/devtools/intellij/quarkus/lsp4ij/LanguageServerWrapper.java#L727 is called by the language server when initialized is call at https://github.com/redhat-developer/intellij-quarkus/blob/afa96c3cc72fda4d418c411e950994920372d123/src/main/java/com/redhat/devtools/intellij/quarkus/lsp4ij/LanguageServerWrapper.java#L327

So my fix is just to initialize the initializeFuture before calling the languageServer.initialized.