### PR TITLE
fix: IllegalStateException: Synchronizer should apply to only a single document, which is the one it was instantiated for

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp4ij/LanguageServerWrapper.java
@@ -595,7 +595,10 @@ public class LanguageServerWrapper {
                     }
                 }
                 DocumentContentSynchronizer listener = new DocumentContentSynchronizer(this, theDocument, syncKind);
-                theDocument.addDocumentListener(listener);
+                theDocument.addDocumentListener(listener, () -> {
+                    // The document changed, remove the DocumentContentSynchronizer from the cache
+                    LanguageServerWrapper.this.connectedDocuments.remove(thePath);
+                });
                 LanguageServerWrapper.this.connectedDocuments.put(thePath, listener);
                 return listener.didOpenFuture;
             }


### PR DESCRIPTION
fix: IllegalStateException: Synchronizer should apply to only a single document, which is the one it was instantiated for

Fixes #752