### PR TITLE
fix: Don't show quickfix for disable validation for application.properties since IJ quarkus doesn't support it.

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusServer.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusServer.java
@@ -51,7 +51,7 @@ public class QuarkusServer extends ProcessStreamConnectionProvider {
         Map<String, Object> extendedClientCapabilities = new HashMap<>();
         Map<String, Object> commands = new HashMap<>();
         Map<String, Object> commandsKind = new HashMap<>();
-        commandsKind.put("valueSet", Arrays.asList("microprofile.command.configuration.update", "microprofile.command.open.uri"));
+        commandsKind.put("valueSet", Arrays.asList(/* TODO support "microprofile.command.configuration.update",*/ "microprofile.command.open.uri"));
         commands.put("commandsKind", commandsKind);
         extendedClientCapabilities.put("commands", commands);
         extendedClientCapabilities.put("completion", new HashMap<>());


### PR DESCRIPTION
Don't show quickfix for disable validation for application.properties since IJ quarkus doesn't support it.

This PR remove the quickfix to ignore validation since IJ Quarkus cannot support it

![image](https://user-images.githubusercontent.com/1932211/233687670-1597ef19-e27a-45b5-90ec-acc4bdc1f503.png)
