### PR TITLE
feat: Support jakarta namespace with microprofile metrics

### DIFF
--- a/projects/lsp4mp/projects/maven/open-liberty/src/main/java/com/demo/rest/IncorrectScopeJakarta.java
+++ b/projects/lsp4mp/projects/maven/open-liberty/src/main/java/com/demo/rest/IncorrectScopeJakarta.java
@@ -1,0 +1,17 @@
+package com.demo.rest;
+
+import jakarta.ws.rs.Path;
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+
+import jakarta.enterprise.context.RequestScoped;
+
+@RequestScoped
+@Path("/")
+public class IncorrectScopeJakarta {
+
+	@Gauge(name = "Return Int", unit = MetricUnits.NONE, description = "Test method for Gauge annotation")
+	public int returnInt() {
+		return 2;
+	}
+}

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/metrics/MicroProfileMetricsConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/metrics/MicroProfileMetricsConstants.java
@@ -26,10 +26,15 @@ public class MicroProfileMetricsConstants {
 	public static final String DIAGNOSTIC_SOURCE = "microprofile-metrics";
 
 	// CDI Scope Annotations
-	public static final String APPLICATION_SCOPED_ANNOTATION = "javax.enterprise.context.ApplicationScoped";
-	public static final String REQUEST_SCOPED_ANNOTATION = "javax.enterprise.context.RequestScoped";
-	public static final String SESSION_SCOPED_ANNOTATION = "javax.enterprise.context.SessionScoped";
-	public static final String DEPENDENT_ANNOTATION = "javax.enterprise.context.Dependent";
+	public static final String APPLICATION_SCOPED_JAVAX_ANNOTATION = "javax.enterprise.context.ApplicationScoped";
+	public static final String REQUEST_SCOPED_JAVAX_ANNOTATION = "javax.enterprise.context.RequestScoped";
+	public static final String SESSION_SCOPED_JAVAX_ANNOTATION = "javax.enterprise.context.SessionScoped";
+	public static final String DEPENDENT_JAVAX_ANNOTATION = "javax.enterprise.context.Dependent";
+
+	public static final String APPLICATION_SCOPED_JAKARTA_ANNOTATION = "jakarta.enterprise.context.ApplicationScoped";
+	public static final String REQUEST_SCOPED_JAKARTA_ANNOTATION = "jakarta.enterprise.context.RequestScoped";
+	public static final String SESSION_SCOPED_JAKARTA_ANNOTATION = "jakarta.enterprise.context.SessionScoped";
+	public static final String DEPENDENT_JAKARTA_ANNOTATION = "jakarta.enterprise.context.Dependent";
 
 	public static final String REQUEST_SCOPED_ANNOTATION_NAME = "RequestScoped";
 	public static final String SESSION_SCOPED_ANNOTATION_NAME = "SessionScoped";

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/metrics/java/MicroProfileMetricsDiagnosticsParticipant.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/metrics/java/MicroProfileMetricsDiagnosticsParticipant.java
@@ -31,12 +31,15 @@ import org.eclipse.lsp4mp.commons.DocumentFormat;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants.DEPENDENT_ANNOTATION;
 import static com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants.DIAGNOSTIC_SOURCE;
 import static com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants.GAUGE_ANNOTATION;
 import static com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants.METRIC_ID;
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants.REQUEST_SCOPED_ANNOTATION;
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants.SESSION_SCOPED_ANNOTATION;
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants.REQUEST_SCOPED_JAVAX_ANNOTATION;
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants.SESSION_SCOPED_JAVAX_ANNOTATION;
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants.DEPENDENT_JAVAX_ANNOTATION;
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants.REQUEST_SCOPED_JAKARTA_ANNOTATION;
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants.SESSION_SCOPED_JAKARTA_ANNOTATION;
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.metrics.MicroProfileMetricsConstants.DEPENDENT_JAKARTA_ANNOTATION;
 
 /**
  * 
@@ -88,7 +91,8 @@ public class MicroProfileMetricsDiagnosticsParticipant implements IJavaDiagnosti
 		String uri = context.getUri();
 		IPsiUtils utils = context.getUtils();
 		DocumentFormat documentFormat = context.getDocumentFormat();
-		boolean hasInvalidScopeAnnotation = AnnotationUtils.hasAnyAnnotation(classType, REQUEST_SCOPED_ANNOTATION, SESSION_SCOPED_ANNOTATION, DEPENDENT_ANNOTATION);
+		boolean hasInvalidScopeAnnotation = AnnotationUtils.hasAnyAnnotation(classType, REQUEST_SCOPED_JAVAX_ANNOTATION, SESSION_SCOPED_JAVAX_ANNOTATION, DEPENDENT_JAVAX_ANNOTATION,
+																						REQUEST_SCOPED_JAKARTA_ANNOTATION, SESSION_SCOPED_JAKARTA_ANNOTATION, DEPENDENT_JAKARTA_ANNOTATION);
 		// check for Gauge annotation for Diagnostic 1 only if the class has an invalid
 		// scope annotation
 		if (hasInvalidScopeAnnotation) {


### PR DESCRIPTION
Port of https://github.com/eclipse/lsp4mp/commit/874375de68fa06bc9b610b46e15578bf4733c25a to IDEA
Part of https://github.com/redhat-developer/intellij-quarkus/issues/806 and https://github.com/redhat-developer/intellij-quarkus/issues/803

Fixes context.getProject() returning null when calling CodeActionHandler.resolveCodeAction

Signed-off-by: Fred Bricon <fbricon@gmail.com>
