### PR TITLE
fix: consume LSP request codeActions only if language server supports it

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp4ij/LSPIJUtils.java
@@ -319,15 +319,10 @@ public class LSPIJUtils {
         ApplicationManager.getApplication().runWriteAction(() -> edits.forEach(edit -> applyEdit(editor, edit, document)));
     }
 
-    public static boolean hasCapability(Either<Boolean, ? extends Object> eitherCapability) {
-        if(eitherCapability != null) {
-            if (eitherCapability.isLeft()) {
-                return eitherCapability.getLeft();
-            } else {
-                return eitherCapability.getRight() != null;
-            }
-        } else {
+    public static boolean hasCapability(final Either<Boolean, ? extends Object> eitherCapability) {
+        if(eitherCapability == null) {
             return false;
         }
+        return eitherCapability.isRight() || (eitherCapability.isLeft() && eitherCapability.getLeft());
     }
 }


### PR DESCRIPTION
Consume LSP request codeActions only if language server supports it

Today we use LSP4IJ with MicroProfile and Qute LS which have code actions capability. But if the language server has not the codeAction capability it consumes the codeActions request which throws an UnsuportedOperationException.

This PR check if the language server has the code action capability. 

See https://github.com/redhat-developer/intellij-quarkus/pull/819#discussion_r1179687022