### PR TITLE
fix: Prevent NPE in qute's AnnotationUtils.isMatchAnnotation

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/utils/AnnotationUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/utils/AnnotationUtils.java
@@ -76,6 +76,9 @@ public class AnnotationUtils {
 	 *         false otherwise.
 	 */
 	public static boolean isMatchAnnotation(PsiAnnotation annotation, String annotationName) {
+		if(annotation == null || annotation.getQualifiedName() == null){
+			return false;
+		}
 		// Annotation name is the fully qualified name of the annotation class (ex :
 		// org.eclipse.microprofile.config.inject.ConfigProperties)
 		// - when IAnnotation comes from binary, IAnnotation#getElementName() =


### PR DESCRIPTION
Simple fix to prevent NPE in qute's AnnotationUtils.isMatchAnnotation, but I'm missing some context, so have no matching unit test.
Fixes #847