### PR TITLE
fix: make sure files can be found when running on WSL

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/core/ls/PsiUtilsLSImpl.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/core/ls/PsiUtilsLSImpl.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiDocumentManager;
@@ -129,7 +130,7 @@ public class PsiUtilsLSImpl implements IPsiUtils {
     @Override
     public VirtualFile findFile(String uri) throws IOException {
         //return LocalFileSystem.getInstance().refreshAndFindFileByIoFile(Paths.get(new URI(uri)).toFile());
-        return VfsUtil.findFileByURL(new URL(uri));
+        return VirtualFileManager.getInstance().findFileByUrl(VfsUtilCore.fixURLforIDEA(uri));
     }
 
     @Override


### PR DESCRIPTION
Calling `VfsUtil.findFileByURL` fails for WSL files as it calls [`VfsUtilCore.convertFromUrl`](https://github.com/JetBrains/intellij-community/blob/0d4a74d99cd22d1f092ff67480537c214497ac9f/platform/core-api/src/com/intellij/openapi/vfs/VfsUtilCore.java#L491-L512), which [strips leading `//` ](https://github.com/JetBrains/intellij-community/blob/0d4a74d99cd22d1f092ff67480537c214497ac9f/platform/core-api/src/com/intellij/openapi/vfs/VfsUtilCore.java#L508-L511) from `file:////wsl$` uris, into `file://wsl$`. 

This bug was reported upstream as https://youtrack.jetbrains.com/issue/IDEA-83879/OpenAPI-com.intellij.openapi.vfs.VfsUtilconvertFromUrl-strips-volume-identifiers-on-Windows. 

The fix is to call `VirtualFileManager.getInstance().findFileByUrl(uri);` instead, as mentioned in the upstream bug report.

Fixes #735 
