### PR TITLE
fix: Collect Qute user tags from templates/tags of dependency JARS (#872)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/template/QuarkusIntegrationForQute.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/template/QuarkusIntegrationForQute.java
@@ -54,7 +54,7 @@ import com.redhat.qute.commons.usertags.UserTagInfo;
  */
 public class QuarkusIntegrationForQute {
 
-	private static final String TEMPLATES_TAGS_ENTRY = "templates.tags";
+	private static final String TEMPLATES_TAGS_ENTRY = "templates/tags";
 	private static final Logger LOGGER = Logger.getLogger(QuarkusIntegrationForQute.class.getName());
 
 	public static DataModelProject<DataModelTemplate<DataModelParameter>> getDataModelProject(Module javaProject,


### PR DESCRIPTION
fix: Collect Qute user tags from templates/tags of dependency JARS (#872)

Fixes #872

This PRs provides the capability to collect Qute user tags from JAR Renarde:

![image](https://github.com/redhat-developer/intellij-quarkus/assets/1932211/a98438e0-4c98-4080-b82b-1e9b0b64e68d)
