### PR TITLE
fix: Typo 'Quakus' in the Quarkus language server description (#883)

### DIFF
--- a/src/main/resources/META-INF/lsp.xml
+++ b/src/main/resources/META-INF/lsp.xml
@@ -38,7 +38,7 @@
           <li><b>Java</b> files.</li>
           <li>and <b>microprofile-config.properties</b> files.</li>
         </ul>
-        This language server is extended with <a href="https://github.com/redhat-developer/quarkus-ls" >Quakus extension</a> to provide <a href="https://quarkus.io/">Quarkus</a> support in <b>application.properties</b> file.
+        This language server is extended with <a href="https://github.com/redhat-developer/quarkus-ls" >Quarkus extension</a> to provide <a href="https://quarkus.io/">Quarkus</a> support in <b>application.properties</b> file.
         ]]>
       </description>
     </server>


### PR DESCRIPTION
fix: Typo 'Quakus' in the Quarkus language server description (#883)

Fixes #883