### PR TITLE
fix: LSP console shouldn't be hidden when IJ is indexing

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/LSPConsoleToolWindowFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/LSPConsoleToolWindowFactory.java
@@ -13,6 +13,7 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4ij.console;
 
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
@@ -26,7 +27,7 @@ import org.jetbrains.annotations.NotNull;
  *
  * @author Angelo ZERR
  */
-public class LSPConsoleToolWindowFactory implements ToolWindowFactory {
+public class LSPConsoleToolWindowFactory implements ToolWindowFactory, DumbAware {
 
     @Override
     public void createToolWindowContent(@NotNull Project project, @NotNull ToolWindow toolWindow) {


### PR DESCRIPTION
Keep LSP console displayed when IJ is indexing, by making LSPConsoleToolWindowFactory implement DumbAware
See https://plugins.jetbrains.com/docs/intellij/tool-windows.html#contents-tabs