### PR TITLE
build: show failed assertions in gradle builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import groovy.time.TimeCategory
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     id "org.jetbrains.intellij" version "1.10.1"
@@ -121,6 +124,19 @@ tasks.withType(Test) {
     systemProperty 'idea.log.leaked.projects.in.tests', 'false'
     systemProperty 'idea.maven.test.mirror', 'https://repo1.maven.org/maven2'
     systemProperty 'com.redhat.devtools.intellij.telemetry.mode', 'disabled'
+
+    testLogging {
+        events TestLogEvent.FAILED, TestLogEvent.SKIPPED, TestLogEvent.PASSED
+        showExceptions true
+        exceptionFormat TestExceptionFormat.FULL
+        showCauses true
+        showStackTraces true
+        showStandardStreams = false
+    }
+    afterTest { descriptor, result ->
+        def totalTime = TimeCategory.minus(new Date(result.endTime), new Date(result.startTime))
+        println "$descriptor.name took $totalTime"
+    }
 }
 
 tasks.withType(Copy) {


### PR DESCRIPTION
Failed test assertions should now be available directly from the gradle build output, e.g.:

```
  ./gradlew test --tests '*TemplateGetDataModelProjectTest'

> Configure project :
[gradle-intellij-plugin :] Gradle IntelliJ Plugin is outdated: 1.10.1. Update `org.jetbrains.intellij` to: 1.13.3

> Task :test
OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.intellij.util.ref.DebugReflectionUtil (file:/Users/fbricon/.gradle/caches/modules-2/files-2.1/com.jetbrains.intellij.idea/ideaIC/2020.3/22cef0fc611e4b9642a48bc955b2b7aacb13bd4d/ideaIC-2020.3/lib/platform-impl.jar) to field java.util.concurrent.locks.ReentrantLock.serialVersionUID
WARNING: Please consider reporting this to the maintainers of com.intellij.util.ref.DebugReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

com.redhat.devtools.intellij.qute.psi.template.TemplateGetDataModelProjectTest > testquteQuickStart FAILED
    org.junit.ComparisonFailure: Expect io.quarkus.qute.runtime.extensions.TimeTemplateExtension but was io.quarkus.qute.runtime.extensions.TimeTemplateExtensions for time:format(dateTimeObject : java.lang.Object, pattern : java.lang.String) : java.lang.String expected:<...imeTemplateExtension[]> but was:<...imeTemplateExtension[s]>
        at org.junit.Assert.assertEquals(Assert.java:115)
        at com.redhat.devtools.intellij.qute.psi.template.TemplateGetDataModelProjectTest.assertValueResolver(TemplateGetDataModelProjectTest.java:380)
        at com.redhat.devtools.intellij.qute.psi.template.TemplateGetDataModelProjectTest.assertValueResolver(TemplateGetDataModelProjectTest.java:369)
        at com.redhat.devtools.intellij.qute.psi.template.TemplateGetDataModelProjectTest.assertValueResolver(TemplateGetDataModelProjectTest.java:364)
        at com.redhat.devtools.intellij.qute.psi.template.TemplateGetDataModelProjectTest.testValueResolversFromTemplateExtension(TemplateGetDataModelProjectTest.java:245)
        at com.redhat.devtools.intellij.qute.psi.template.TemplateGetDataModelProjectTest.testquteQuickStart(TemplateGetDataModelProjectTest.java:59)

1 test completed, 1 failed

> Task :test FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':test'.
> There were failing tests. See the report at: file:///Users/fbricon/Dev/projects/intellij-quarkus/build/reports/tests/test/index.html

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.6/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 38s
17 actionable tasks: 8 executed, 9 up-to-date
```