### PR TITLE
fix: ensure document is not null in LSPIJUtils.toLocation

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/LSPIJUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/LSPIJUtils.java
@@ -181,8 +181,10 @@ public class LSPIJUtils {
         if (sourceElement != null) {
             PsiFile file = sourceElement.getContainingFile();
             Document document = PsiDocumentManager.getInstance(psiMember.getProject()).getDocument(file);
-            TextRange range = sourceElement.getTextRange();
-            return toLocation(file, toRange(range, document));
+            if (document != null) {
+                TextRange range = sourceElement.getTextRange();
+                return toLocation(file, toRange(range, document));
+            }
         }
         return null;
     }


### PR DESCRIPTION
Fixes #941

API says `PsiDocumentManager.getDocument(file)` can return `null`, so it should be guarded against.
As to why it returns `null` in some cases, I have no idea.
