### PR TITLE
fix: ensure LSPTextHover.generateDoc ignores elements from different files

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/operations/hover/LSPTextHover.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/operations/hover/LSPTextHover.java
@@ -111,6 +111,9 @@ public class LSPTextHover extends DocumentationProviderEx implements ExternalDoc
     @Nullable
     @Override
     public String generateDoc(PsiElement element, @Nullable PsiElement originalElement) {
+        if (originalElement == null || !Objects.equals(element.getContainingFile(), originalElement.getContainingFile())) {
+            return null;
+        }
         Editor editor = LSPIJUtils.editorForElement(element);
         if (editor == null) {
             return null;


### PR DESCRIPTION
Fixes #960 
We ensure both element and originalElement refer to the same file, so it doesn't generate an exception.
No tests since the exception was just logged