### PR TITLE
fix: properly wrap QuteSupportForJava methods in runReadAction

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/QuteSupportForJava.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/QuteSupportForJava.java
@@ -48,14 +48,14 @@ public class QuteSupportForJava {
     public List<? extends CodeLens> codeLens(QuteJavaCodeLensParams params, IPsiUtils utils, ProgressIndicator monitor) {
         String uri = params.getUri();
 
-        Module javaProject = QuteSupportForTemplate.getJavaProjectFromTemplateFile(uri, utils);
-        if (javaProject == null) {
-            return Collections.emptyList();
-        }
-
-        final var refinedUtils = utils.refine(javaProject);
         return ApplicationManager.getApplication()
                 .runReadAction((Computable<List<? extends CodeLens>>) () -> {
+                    Module javaProject = QuteSupportForTemplate.getJavaProjectFromTemplateFile(uri, utils);
+                    if (javaProject == null) {
+                        return Collections.emptyList();
+                    }
+
+                    final var refinedUtils = utils.refine(javaProject);
                     PsiFile typeRoot = resolveTypeRoot(uri, refinedUtils, monitor);
                     if (monitor.isCanceled()) {
                         return Collections.emptyList();
@@ -98,17 +98,14 @@ public class QuteSupportForJava {
     public List<DocumentLink> documentLink(QuteJavaDocumentLinkParams params, IPsiUtils utils,
                                            ProgressIndicator monitor) {
         String uri = params.getUri();
-
-        Module javaProject = QuteSupportForTemplate.getJavaProjectFromTemplateFile(uri, utils);
-        if (javaProject == null) {
-            return Collections.emptyList();
-        }
-
-        utils = utils.refine(javaProject);
-
-        final var refinedUtils = utils.refine(javaProject);
         return ApplicationManager.getApplication()
                 .runReadAction((Computable<List<DocumentLink>>) () -> {
+                    Module javaProject = QuteSupportForTemplate.getJavaProjectFromTemplateFile(uri, utils);
+                    if (javaProject == null) {
+                        return Collections.emptyList();
+                    }
+
+                    var refinedUtils = utils.refine(javaProject);
                     PsiFile typeRoot = resolveTypeRoot(uri, refinedUtils, monitor);
                     if (monitor.isCanceled()) {
                         return Collections.emptyList();


### PR DESCRIPTION
Fixes 
```
com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: Read access is allowed from inside read-action or Event Dispatch Thread (EDT) only (see Application.runReadAction()); see https://jb.gg/ij-platform-threading for details
Current thread: Thread[JobScheduler FJ pool 0/11,4,main] 1236825056 (EventQueue.isDispatchThread()=false)
SystemEventQueueThread: Thread[AWT-EventQueue-0,6,main] 208767435
	at com.intellij.openapi.application.impl.ApplicationImpl.createThreadAccessException(ApplicationImpl.java:1086)
	at com.intellij.openapi.application.impl.ApplicationImpl.assertReadAccessAllowed(ApplicationImpl.java:1041)
	at com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexDataImpl.ensureIsUpToDate(WorkspaceFileIndexDataImpl.kt:132)
	at com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexDataImpl.getFileInfo(WorkspaceFileIndexDataImpl.kt:74)
	at com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexImpl.getFileInfo(WorkspaceFileIndexImpl.kt:220)
	at com.intellij.workspaceModel.core.fileIndex.impl.WorkspaceFileIndexImpl.findFileSetWithCustomData(WorkspaceFileIndexImpl.kt:205)
	at com.intellij.openapi.roots.impl.ProjectFileIndexImpl.getModuleForFile(ProjectFileIndexImpl.java:88)
	at [com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.core.ls](http://com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.core.ls/).PsiUtilsLSImpl.getModule(PsiUtilsLSImpl.java:83)
	at com.redhat.devtools.intellij.qute.psi.QuteSupportForTemplate.getJavaProjectFromTemplateFile(QuteSupportForTemplate.java:304)
	at com.redhat.devtools.intellij.qute.psi.QuteSupportForJava.documentLink(QuteSupportForJava.java:102)
	at com.redhat.devtools.intellij.qute.lsp.QuteLanguageClient.lambda$getJavaDocumentLink$14(QuteLanguageClient.java:163)
	at com.redhat.devtools.intellij.lsp4ij.IndexAwareLanguageClient.runTask(IndexAwareLanguageClient.java:60)
	at com.redhat.devtools.intellij.lsp4ij.IndexAwareLanguageClient$1.run(IndexAwareLanguageClient.java:39)
	at com.intellij.openapi.progress.impl.CoreProgressManager.startTask(CoreProgressManager.java:427)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.startTask(ProgressManagerImpl.java:115)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcessWithProgressInCurrentThread$11(CoreProgressManager.java:556)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$2(CoreProgressManager.java:185)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$13(CoreProgressManager.java:603)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:678)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:634)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:602)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:61)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:172)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcessWithProgressInCurrentThread(CoreProgressManager.java:556)
	at com.intellij.openapi.progress.impl.CoreProgressManager.run(CoreProgressManager.java:362)
	at com.redhat.devtools.intellij.lsp4ij.IndexAwareLanguageClient.lambda$runAsBackground$0(IndexAwareLanguageClient.java:36)
	at com.redhat.devtools.intellij.lsp4ij.IndexAwareLanguageClient.lambda$runAsBackground$1(IndexAwareLanguageClient.java:50)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)
```

when running in IDEA EAP