### PR TITLE
feat: map LSP4J CompletionItemKinds to Intellij IDEA icons

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/operations/completion/LSIncompleteCompletionProposal.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/operations/completion/LSIncompleteCompletionProposal.java
@@ -23,13 +23,7 @@ import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.intellij.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.intellij.lsp4ij.command.internal.CommandExecutor;
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.lsp4j.Command;
-import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.InsertReplaceEdit;
-import org.eclipse.lsp4j.InsertTextFormat;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.jetbrains.annotations.NotNull;
@@ -39,6 +33,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static com.redhat.devtools.intellij.lsp4ij.ui.IconMapper.getIcon;
 
 public class LSIncompleteCompletionProposal extends LookupElement {
     private static final Logger LOGGER = LoggerFactory.getLogger(LSIncompleteCompletionProposal.class);
@@ -185,12 +181,15 @@ public class LSIncompleteCompletionProposal extends LookupElement {
     }
 
     private boolean isDeprecated() {
-        return item.getDeprecated() != null && item.getDeprecated().booleanValue();
+        return (item.getTags() != null && item.getTags().contains(CompletionItemTag.Deprecated))
+        || (item.getDeprecated() != null && item.getDeprecated().booleanValue());
     }
 
     @Override
     public void renderElement(LookupElementPresentation presentation) {
         presentation.setItemText(item.getLabel());
+        presentation.setTypeText(item.getDetail());
+        presentation.setIcon(getIcon(item.getKind()));
         if (isDeprecated()) {
             presentation.setStrikeout(true);
         }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/ui/IconMapper.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/ui/IconMapper.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.intellij.lsp4ij.ui;
+
+import com.intellij.icons.AllIcons;
+import com.intellij.openapi.util.IconLoader;
+import org.eclipse.lsp4j.CompletionItemKind;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.Icon;
+
+/**
+ * Maps LSP4J kinds to Intellij Icons. See the <a href="https://jetbrains.design/intellij/resources/icons_list/" target="_blank">JetBrains icon list</a> for reference.
+ */
+public class IconMapper {
+
+    // Copied from IntelliJ icons. To be removed once the minimal supported version of IDEA is > 213
+    // See https://github.com/JetBrains/intellij-community/blob/50157fc8eec4af77f67bd468ada4dff39daa1b88/platform/util/ui/src/com/intellij/icons/AllIcons.java#L415
+    // Original https://github.com/JetBrains/intellij-community/blob/50157fc8eec4af77f67bd468ada4dff39daa1b88/platform/icons/src/nodes/template.svg
+    public static final @NotNull Icon Template = load("images/nodes/template.svg");
+
+    // Copied from IntelliJ icons. To be removed once the minimal supported version of IDEA is > 232
+    // See https://github.com/JetBrains/intellij-community/blob/50157fc8eec4af77f67bd468ada4dff39daa1b88/platform/util/ui/src/com/intellij/icons/ExpUiIcons.java#L226
+    // Original light https://github.com/JetBrains/intellij-community/blob/50157fc8eec4af77f67bd468ada4dff39daa1b88/platform/icons/src/expui/fileTypes/text.svg
+    // Original dark https://github.com/JetBrains/intellij-community/blob/50157fc8eec4af77f67bd468ada4dff39daa1b88/platform/icons/src/expui/fileTypes/text_dark.svg
+    public static final @NotNull Icon Text = load("images/expui/fileTypes/text.svg");
+
+
+    private IconMapper(){
+    }
+
+
+    /**
+     * Maps LSP4J {@link CompletionItemKind} to Intellij Icons
+     */
+    public static @Nullable Icon getIcon(@Nullable CompletionItemKind kind) {
+        if (kind == null) {
+            return null;
+        }
+
+        switch (kind) {
+            case Snippet:
+                return Template;
+            case Text:
+                return Text;
+            case Constructor:
+                return AllIcons.Nodes.ClassInitializer;
+            case Method:
+                return AllIcons.Nodes.Method;
+            case Function:
+                return AllIcons.Nodes.Function;
+            case EnumMember://No matching icon, IDEA show enum members as fields
+            case Field:
+                return AllIcons.Nodes.Field;
+            case Value: //No matching icon
+            case Variable:
+                return AllIcons.Nodes.Variable;
+            case Class:
+                return AllIcons.Nodes.Class;
+            case Interface:
+                return AllIcons.Nodes.Interface;
+            case Module:
+                return AllIcons.Nodes.Module;
+            case Property:
+                return AllIcons.Nodes.Property;
+            case Unit:
+                return AllIcons.Nodes.Test;
+            case Enum:
+                return AllIcons.Nodes.Enum;
+            case File:
+                return AllIcons.FileTypes.Any_type;
+            case Folder:
+                return AllIcons.Nodes.Folder;
+            case Constant:
+                return AllIcons.Nodes.Constant;
+            case TypeParameter:
+                return AllIcons.Nodes.Parameter;
+            //No matching icons, no fallback
+            case Keyword:
+            case Struct:
+            case Event:
+            case Operator:
+            case Reference:
+            case Color:
+            default:
+                return AllIcons.Nodes.EmptyNode;
+        }
+    }
+
+    private static @NotNull Icon load(String iconPath) {
+        return IconLoader.getIcon(iconPath, IconMapper.class);
+    }
+}

--- a/src/main/resources/images/expui/fileTypes/text.svg
+++ b/src/main/resources/images/expui/fileTypes/text.svg
@@ -1,0 +1,7 @@
+<!-- Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2" y="12" width="8" height="1" rx="0.5" fill="#6C707E"/>
+<rect x="2" y="6" width="8" height="1" rx="0.5" fill="#6C707E"/>
+<rect x="2" y="9" width="12" height="1" rx="0.5" fill="#6C707E"/>
+<rect x="2" y="3" width="12" height="1" rx="0.5" fill="#6C707E"/>
+</svg>

--- a/src/main/resources/images/expui/fileTypes/text_dark.svg
+++ b/src/main/resources/images/expui/fileTypes/text_dark.svg
@@ -1,0 +1,7 @@
+<!-- Copyright 2000-2022 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="2" y="12" width="8" height="1" rx="0.5" fill="#CED0D6"/>
+<rect x="2" y="6" width="8" height="1" rx="0.5" fill="#CED0D6"/>
+<rect x="2" y="9" width="12" height="1" rx="0.5" fill="#CED0D6"/>
+<rect x="2" y="3" width="12" height="1" rx="0.5" fill="#CED0D6"/>
+</svg>

--- a/src/main/resources/images/nodes/template.svg
+++ b/src/main/resources/images/nodes/template.svg
@@ -1,0 +1,6 @@
+<!-- Copyright 2000-2021 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file. -->
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1" y="9" width="14" height="2" fill="#9AA7B0" fill-opacity="0.8"/>
+<rect x="2" y="12" width="12" height="2" fill="#9AA7B0" fill-opacity="0.8"/>
+<path d="M11 2H5V4L7 5V9H9V5L11 4V2Z" fill="#9AA7B0" fill-opacity="0.8"/>
+</svg>

--- a/src/test/java/com/redhat/devtools/intellij/lsp4ij/ui/IconMapperTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/lsp4ij/ui/IconMapperTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.intellij.lsp4ij.ui;
+
+import org.eclipse.lsp4j.CompletionItemKind;
+import org.junit.Test;
+
+import static com.redhat.devtools.intellij.lsp4ij.ui.IconMapper.getIcon;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class IconMapperTest {
+
+    @Test
+    public void getIconTest()  {
+        assertNull(getIcon(null));
+        for (CompletionItemKind value : CompletionItemKind.values()) {
+            assertNotNull(getIcon(value), "Missing matching icon for "+value);
+        }
+    }
+}


### PR DESCRIPTION
Provides icons for completion results.

"recent" icons from IJ were copied over to work with older IJ versions still supported.

Example for application.properties completion:

<img width="463" alt="Screenshot 2023-06-28 at 20 41 18" src="https://github.com/redhat-developer/intellij-quarkus/assets/148698/af15a871-793b-4d8f-af29-e8829542bc0f">
