### PR TITLE
fix: avoid polluting logs with ProcessCanceledException stacktraces on Ctrl+hover

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "org.jetbrains.intellij" version "1.14.1"
+    id "org.jetbrains.intellij" version "1.14.2"
     id 'idea'
     id 'java'
     id 'org.jetbrains.kotlin.jvm' version '1.6.0'

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/LanguageServiceAccessor.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/LanguageServiceAccessor.java
@@ -50,7 +50,7 @@ public class LanguageServiceAccessor {
         this.project = project;
     }
 
-    private Set<LanguageServerWrapper> startedServers = new HashSet<>();
+    private final Set<LanguageServerWrapper> startedServers = new HashSet<>();
     private Map<StreamConnectionProvider, LanguageServersRegistry.LanguageServerDefinition> providersToLSDefinitions = new HashMap<>();
 
     /**
@@ -351,6 +351,8 @@ public class LanguageServiceAccessor {
                     .filter(wrapper -> {
                         try {
                             return wrapper.isConnectedTo(path) || LanguageServersRegistry.getInstance().matches(document, wrapper.serverDefinition, project);
+                        } catch (ProcessCanceledException cancellation) {
+                            throw cancellation;
                         } catch (Exception e) {
                             LOGGER.warn(e.getLocalizedMessage(), e);
                             return false;


### PR DESCRIPTION
In IJ 2023.1.3, 

- open https://github.com/ia3andy/quarkus-blast/
- open src/main/resources/templates/GameController/game.html
- Ctrl+hover over https://github.com/ia3andy/quarkus-blast/blob/main/src/main/resources/templates/GameController/game.html#L1

console is littered with stacktraces of JobCancellationException:

```
2023-07-07 10:14:38,811 [ 135606]   WARN - com.redhat.devtools.intellij.lsp4ij.LanguageServiceAccessor - kotlinx.coroutines.JobCancellationException: StandaloneCoroutine was cancelled; job=StandaloneCoroutine{Cancelling}@570e68cb
com.intellij.openapi.progress.JobCanceledException: kotlinx.coroutines.JobCancellationException: StandaloneCoroutine was cancelled; job=StandaloneCoroutine{Cancelling}@570e68cb
	at com.intellij.openapi.progress.Cancellation.checkCancelled(Cancellation.java:44)
	at com.intellij.openapi.progress.impl.CoreProgressManager.doCheckCanceled(CoreProgressManager.java:133)
	at com.intellij.openapi.progress.ProgressManager.checkCanceled(ProgressManager.java:227)
	at com.intellij.openapi.roots.impl.OrderEnumeratorBase.processEntries(OrderEnumeratorBase.java:295)
	at com.intellij.openapi.roots.impl.ModuleOrderEnumerator.forEach(ModuleOrderEnumerator.java:33)
	at com.intellij.openapi.roots.impl.OrderEnumeratorBase.process(OrderEnumeratorBase.java:372)
	at com.intellij.openapi.roots.impl.ModuleOrderEnumerator.process(ModuleOrderEnumerator.java:17)
	at com.redhat.devtools.intellij.qute.lang.QuteLanguageSubstitutor.isQuteModule(QuteLanguageSubstitutor.java:38)
	at com.redhat.devtools.intellij.qute.lang.QuteLanguageSubstitutor.getLanguage(QuteLanguageSubstitutor.java:68)
	at com.intellij.psi.LanguageSubstitutors.substituteLanguage(LanguageSubstitutors.java:58)
	at com.intellij.lang.LanguageUtil.getLanguageForPsi(LanguageUtil.java:51)
	at com.intellij.lang.LanguageUtil.getLanguageForPsi(LanguageUtil.java:33)
	at com.redhat.devtools.intellij.lsp4ij.LSPIJUtils.lambda$getFileLanguage$0(LSPIJUtils.java:79)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:891)
	at com.intellij.openapi.application.ReadAction.compute(ReadAction.java:69)
	at com.redhat.devtools.intellij.lsp4ij.LSPIJUtils.getFileLanguage(LSPIJUtils.java:79)
	at com.redhat.devtools.intellij.lsp4ij.LSPIJUtils.getDocumentLanguage(LSPIJUtils.java:357)
	at com.redhat.devtools.intellij.lsp4ij.LanguageServersRegistry.matches(LanguageServersRegistry.java:256)
	at com.redhat.devtools.intellij.lsp4ij.LanguageServiceAccessor.lambda$getLSWrappers$4(LanguageServiceAccessor.java:353)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178)
	at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1707)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at com.redhat.devtools.intellij.lsp4ij.LanguageServiceAccessor.getLSWrappers(LanguageServiceAccessor.java:361)
	at com.redhat.devtools.intellij.lsp4ij.LanguageServiceAccessor.getLanguageServers(LanguageServiceAccessor.java:577)
	at com.redhat.devtools.intellij.lsp4ij.operations.navigation.LSPGotoDeclarationHandler.getGotoDeclarationTargets(LSPGotoDeclarationHandler.java:62)
	at com.intellij.codeInsight.navigation.impl.GtdProvidersKt.fromGTDProvidersInner(gtdProviders.kt:30)
	at com.intellij.codeInsight.navigation.impl.GtdProvidersKt.access$fromGTDProvidersInner(gtdProviders.kt:1)
	at com.intellij.codeInsight.navigation.impl.GtdProvidersKt$fromGTDProviders$1.invoke(gtdProviders.kt:17)
	at com.intellij.codeInsight.navigation.impl.GtdProvidersKt$fromGTDProviders$1.invoke(gtdProviders.kt:16)
	at com.intellij.codeInsight.navigation.impl.CommonKt.processInjectionThenHost(common.kt:25)
	at com.intellij.codeInsight.navigation.impl.GtdProvidersKt.fromGTDProviders(gtdProviders.kt:16)
	at com.intellij.codeInsight.navigation.actions.GotoDeclarationOrUsageHandler2.gotoDeclarationOrUsages(GotoDeclarationOrUsageHandler2.kt:32)
	at com.intellij.codeInsight.navigation.actions.GotoDeclarationOrUsageHandler2.getCtrlMouseData(GotoDeclarationOrUsageHandler2.kt:45)
	at com.intellij.codeInsight.navigation.actions.GotoDeclarationAction.getCtrlMouseData(GotoDeclarationAction.java:96)
	at com.intellij.codeInsight.navigation.CtrlMouseHandler2$computeInReadAction$1.invoke(CtrlMouseHandler.kt:229)
	at com.intellij.codeInsight.navigation.CtrlMouseHandler2$computeInReadAction$1.invoke(CtrlMouseHandler.kt:228)
	at com.intellij.lang.documentation.ide.impl.DocumentationTargetHoverInfoKt.injectedThenHost(DocumentationTargetHoverInfo.kt:76)
	at com.intellij.codeInsight.navigation.CtrlMouseHandler2.computeInReadAction(CtrlMouseHandler.kt:228)
	at com.intellij.codeInsight.navigation.CtrlMouseHandler2.access$computeInReadAction(CtrlMouseHandler.kt:70)
	at com.intellij.codeInsight.navigation.CtrlMouseHandler2$compute$2$1.invoke(CtrlMouseHandler.kt:216)
	at com.intellij.codeInsight.navigation.CtrlMouseHandler2$compute$2$1.invoke(CtrlMouseHandler.kt:215)
	at com.intellij.openapi.application.rw.InternalReadAction.insideReadAction(InternalReadAction.kt:108)
	at com.intellij.openapi.application.rw.InternalReadAction.access$insideReadAction(InternalReadAction.kt:15)
	at com.intellij.openapi.application.rw.InternalReadAction$tryReadCancellable$1.invoke(InternalReadAction.kt:92)
	at com.intellij.openapi.application.rw.InternalReadAction$tryReadCancellable$1.invoke(InternalReadAction.kt:91)
	at com.intellij.openapi.progress.CancellationKt.withCurrentJob$lambda$0(cancellation.kt:17)
	at com.intellij.openapi.progress.Cancellation.withCurrentJob(Cancellation.java:60)
	at com.intellij.openapi.progress.CancellationKt.withCurrentJob(cancellation.kt:17)
	at com.intellij.openapi.progress.CancellationKt.executeWithJobAndCompleteIt(cancellation.kt:126)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal$lambda$1$lambda$0(cancellableReadAction.kt:49)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1102)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal$lambda$1(cancellableReadAction.kt:47)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtilService.runActionAndCancelBeforeWrite(ProgressIndicatorUtilService.java:63)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runActionAndCancelBeforeWrite(ProgressIndicatorUtils.java:129)
	at com.intellij.openapi.application.rw.CancellableReadActionKt.cancellableReadActionInternal(cancellableReadAction.kt:45)
	at com.intellij.openapi.application.rw.InternalReadAction.tryReadCancellable(InternalReadAction.kt:91)
	at com.intellij.openapi.application.rw.InternalReadAction.access$tryReadCancellable(InternalReadAction.kt:15)
	at com.intellij.openapi.application.rw.InternalReadAction$tryReadAction$2.invoke(InternalReadAction.kt:77)
	at com.intellij.openapi.application.rw.InternalReadAction$tryReadAction$2.invoke(InternalReadAction.kt:72)
	at com.intellij.openapi.progress.CancellationKt.withCurrentJob$lambda$0(cancellation.kt:17)
	at com.intellij.openapi.progress.Cancellation.withCurrentJob(Cancellation.java:60)
	at com.intellij.openapi.progress.CancellationKt.withCurrentJob(cancellation.kt:17)
	at com.intellij.openapi.progress.CoroutinesKt.blockingContext(coroutines.kt:193)
	at com.intellij.openapi.application.rw.InternalReadAction.tryReadAction(InternalReadAction.kt:72)
	at com.intellij.openapi.application.rw.InternalReadAction.readLoop(InternalReadAction.kt:64)
	at com.intellij.openapi.application.rw.InternalReadAction.access$readLoop(InternalReadAction.kt:15)
	at com.intellij.openapi.application.rw.InternalReadAction$runReadAction$4.invokeSuspend(InternalReadAction.kt:43)
```

The fix consists in rethrowing the ProcessCanceledException, instead of logging it, as done in [other places](https://github.com/redhat-developer/intellij-quarkus/pull/981).

Bonus commit:
- build: update gradle intellij plugin to 1.14.2

