### PR TITLE
fix: Ensure config_ordinal only appears in MicroProfile projects

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -393,8 +393,7 @@
                                implementationClass="com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.openapi.java.MicroProfileGenerateOpenAPIOperation"/>
 
     <!-- Microprofile Config Static Property support -->
-    
-    <staticPropertyProvider resource="/static-properties/mp-config-metadata.json"/>
+    <staticPropertyProvider resource="/static-properties/mp-config-metadata.json" type="org.eclipse.microprofile.config.Config"/>
 
     <!--quarkus-ls-->
     <configSourceProvider implementation="com.redhat.devtools.intellij.quarkus.psi.internal.providers.QuarkusConfigSourceProvider"/>


### PR DESCRIPTION
Port of https://github.com/eclipse/lsp4mp/commit/caf91c68e7f2fe27072f1f947e3c5476f3289d8f

Part of #806

To test, open a non-quarkus project (eg. Lemminx), add an `src/main/resources/application.properties` file and trigger completion on an empty line. config_ordinal should not appear.