### PR TITLE
feat: mark JAX-RS and Renarde endpoints as implicitly used

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/JavaEEImplicitUsageProvider.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/JavaEEImplicitUsageProvider.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.intellij.lsp4mp4ij.psi.core;
+
+import com.intellij.codeInsight.daemon.ImplicitUsageProvider;
+import com.intellij.psi.PsiElement;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.jaxrs.JaxRsConstants;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.restclient.MicroProfileRestClientConstants;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Automatically declares as used, methods annotated with jakarta.ws.rs.* or javax.ws.rs.* HTTP annotations,
+ * or {@link org.eclipse.microprofile.rest.client.inject.RestClient}
+ */
+public class JavaEEImplicitUsageProvider implements ImplicitUsageProvider {
+
+    @Override
+    public boolean isImplicitUsage(@NotNull PsiElement element) {
+        return isImplicitRead(element) || isImplicitWrite(element);
+    }
+
+    @Override
+    public boolean isImplicitRead(@NotNull PsiElement element) {
+        return AnnotationUtils.hasAnyAnnotation(element, JaxRsConstants.HTTP_METHOD_ANNOTATIONS) ||
+                AnnotationUtils.hasAnnotation(element, MicroProfileRestClientConstants.REST_CLIENT_ANNOTATION);
+    }
+
+    @Override
+    public boolean isImplicitWrite(@NotNull PsiElement element) {
+        return false;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/extensions/renarde/RenardeImplicitUsageProvider.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/extensions/renarde/RenardeImplicitUsageProvider.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.intellij.qute.psi.internal.extensions.renarde;
+
+import com.intellij.codeInsight.daemon.ImplicitUsageProvider;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiModifier;
+import com.redhat.devtools.intellij.qute.psi.internal.QuteJavaConstants;
+import com.redhat.microprofile.psi.internal.quarkus.renarde.java.RenardeUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+
+/**
+ * Automatically declares as used, public methods from classes extending Renarde's {@io.quarkiverse.renarde.Controller}
+ */
+public class RenardeImplicitUsageProvider implements ImplicitUsageProvider {
+    @Override
+    public boolean isImplicitUsage(@NotNull PsiElement element) {
+        return isImplicitRead(element) || isImplicitWrite(element);
+    }
+
+    @Override
+    public boolean isImplicitRead(@NotNull PsiElement element) {
+        PsiClass clazz = null;
+        if (element instanceof PsiClass) {
+            clazz = (PsiClass)element;
+            if (!hasPublicMethods(clazz)) {
+                return false;
+            };
+        } else if (element instanceof PsiMethod) {
+            PsiMethod method = (PsiMethod)element;
+            if (isPublic(method)) {
+                clazz = method.getContainingClass();
+            }
+        }
+        return RenardeUtils.isControllerClass(clazz);
+    }
+
+    private boolean hasPublicMethods(@NotNull PsiClass clazz) {
+        return Arrays.stream(clazz.getAllMethods()).anyMatch(this::isPublic);
+    }
+
+    private boolean isPublic(@NotNull PsiMethod method) {
+        return !method.isConstructor()
+                && method.getContainingClass() != null
+                && !QuteJavaConstants.JAVA_LANG_OBJECT_TYPE.equals(method.getContainingClass().getQualifiedName())
+                && method.getModifierList().hasModifierProperty(PsiModifier.PUBLIC)
+                && !method.getModifierList().hasModifierProperty(PsiModifier.STATIC);
+    }
+
+    @Override
+    public boolean isImplicitWrite(@NotNull PsiElement element) {
+        return false;
+    }
+}

--- a/src/main/resources/META-INF/lsp4ij-quarkus.xml
+++ b/src/main/resources/META-INF/lsp4ij-quarkus.xml
@@ -35,6 +35,9 @@
                              provider="com.redhat.devtools.intellij.lsp4mp4ij.settings.java.MicroProfileJavaConfigurableProvider"/>
     <applicationService id="com.redhat.devtools.intellij.lsp4mp4ij.settings.UserDefinedMicroProfileSettings"
                         serviceImplementation="com.redhat.devtools.intellij.lsp4mp4ij.settings.UserDefinedMicroProfileSettings"/>
+
+    <implicitUsageProvider implementation="com.redhat.devtools.intellij.lsp4mp4ij.psi.core.JavaEEImplicitUsageProvider"/>
+
     <!-- Quarkus -->
     <lang.documentationProvider id="LSPTextHoverProperties" language="Properties" implementationClass="com.redhat.devtools.intellij.lsp4ij.operations.hover.LSPTextHover" order="first"/>
     <externalAnnotator language="Properties"

--- a/src/main/resources/META-INF/lsp4ij-qute.xml
+++ b/src/main/resources/META-INF/lsp4ij-qute.xml
@@ -43,6 +43,7 @@
     <externalAnnotator language="Qute_"
                        implementationClass="com.redhat.devtools.intellij.lsp4ij.operations.documentLink.LSPDocumentLinkAnnotator"/>
     <completion.confidence  language="HTML" order="before htmlText" implementationClass="com.redhat.devtools.intellij.lsp4ij.operations.completion.LSPCompletionConfidence" />
+    <implicitUsageProvider implementation="com.redhat.devtools.intellij.qute.psi.internal.extensions.renarde.RenardeImplicitUsageProvider"/>
   </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
JAX-RS controller:
![Jul-12-2023 12-47-49](https://github.com/redhat-developer/intellij-quarkus/assets/148698/f1b6499b-091d-4ff7-8d97-d5276ba01a9a)


Renarde controller:
![Jul-12-2023 12-27-17](https://github.com/redhat-developer/intellij-quarkus/assets/148698/c48d3d1f-ea6c-4715-832c-a9c90c82d006)

