### PR TITLE
fix: remove extra colon in inlay hints

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/operations/inlayhint/LSPInlayHintInlayProvider.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/operations/inlayhint/LSPInlayHintInlayProvider.java
@@ -141,7 +141,7 @@ public class LSPInlayHintInlayProvider extends AbstractLSPInlayProvider {
             } else {
                 int index = 0;
                 for (InlayHintLabelPart part : label.getRight()) {
-                    InlayPresentation text = createInlayPresentation(editor.getProject(), factory, presentations, p, index, part);
+                    InlayPresentation text = createInlayPresentation(editor.getProject(), factory, p, index, part);
                     if (part.getTooltip() != null && part.getTooltip().isLeft()) {
                         text = factory.withTooltip(part.getTooltip().getLeft(), text);
                     }
@@ -157,15 +157,11 @@ public class LSPInlayHintInlayProvider extends AbstractLSPInlayProvider {
     private InlayPresentation createInlayPresentation(
             Project project,
             PresentationFactory factory,
-            List<InlayPresentation> presentations, Pair<Integer,
-            Pair<InlayHint, LanguageServer>> p,
+            Pair<Integer, Pair<InlayHint, LanguageServer>> p,
             int index,
             InlayHintLabelPart part) {
         InlayPresentation text = factory.smallText(part.getValue());
-        if (!hasCommand(part)) {
-            // No command, create a simple text inlay hint
-            presentations.add(text);
-        } else {
+        if (hasCommand(part)) {
             // InlayHintLabelPart defines a Command, create a clickable inlay hint
             int finalIndex = index;
             text = factory.referenceOnHover(text, (event, translated) ->


### PR DESCRIPTION
Qute Inlay hints are displayed with a double "::"

<img width="279" alt="Screenshot 2023-07-12 at 15 18 01" src="https://github.com/redhat-developer/intellij-quarkus/assets/148698/9b421179-8810-4ce7-bd00-4a513f4f66e3">

The non-command part of the inlay hint was added twice. This PR fixes it:

<img width="256" alt="Screenshot 2023-07-12 at 16 38 08" src="https://github.com/redhat-developer/intellij-quarkus/assets/148698/9f01c45e-5f47-464b-bebe-77fa84bd0289">

