### PR TITLE
feat: provide completion support while indexing process

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/operations/completion/LSContentAssistProcessor.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/operations/completion/LSContentAssistProcessor.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressManager;
+import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.psi.PsiFile;
@@ -45,7 +46,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-public class LSContentAssistProcessor extends CompletionContributor {
+public class LSContentAssistProcessor extends CompletionContributor implements DumbAware {
     private static final Logger LOGGER = LoggerFactory.getLogger(LSContentAssistProcessor.class);
 
     @Override


### PR DESCRIPTION
feat: provide completion support while indexing process

This PR provides the capability to benefit with completion support while the indexing process. For application.properties it is not interesting because it requires to compute properties from Java files (in this case properties are available only when Java files are indexing) but it is interesting for Qute template section completion.