### PR TITLE
fix: Freeze on parameter declaration completion (#1015)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/operations/completion/LSPCompletionContributor.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/operations/completion/LSPCompletionContributor.java
@@ -103,7 +103,9 @@ public class LSPCompletionContributor extends CompletionContributor implements D
             String prefix = completionPrefix.getPrefixFor(lookupItem.getTextEditRange(), item);
             if (prefix != null) {
                 // Add the IJ completion item (lookup item) by using the computed prefix
-                result.withPrefixMatcher(prefix).addElement(groupedLookupItem);
+                result.withPrefixMatcher(prefix)
+                        .caseInsensitive() // set case insentitive to search Java class which starts with upper case
+                        .addElement(groupedLookupItem);
             } else {
                 // Should happens rarely, only when text edit is for multi-lines or if completion is triggered outside the text edit range.
                 // Add the IJ completion item (lookup item) which will use the IJ prefix


### PR DESCRIPTION
fix: Freeze on parameter declaration completion (#1015)

Fixes #1015

It should be fast if you declare the package (ex : `{@java.lang.|`) and little slow if you type directly the class without package (ex : `{@Str|}`. See the following demo:

![ParameterDeclarationInIJ](https://github.com/redhat-developer/intellij-quarkus/assets/1932211/5101a4a8-ddb2-47cf-a757-04660622c812)

Perhaps it is slow because we return too many items? But it is now useable.
