### PR TITLE
fix: No display name is specified for configurable c.r.d.i.lsp4ij.settings.LanguageServerListConfigurable in xml file

### DIFF
--- a/src/main/resources/META-INF/lsp4ij-quarkus.xml
+++ b/src/main/resources/META-INF/lsp4ij-quarkus.xml
@@ -26,11 +26,17 @@
     <!-- MicroProfile settings -->
     <applicationConfigurable groupId="language"
                              id="MicroProfile"
+                             bundle="messages.MicroProfileBundle"
+                             key="microprofile"
                              provider="com.redhat.devtools.intellij.lsp4mp4ij.settings.MicroProfileConfigurableProvider"/>
     <applicationConfigurable parentId="MicroProfile"
                              id="MicroProfileProperties"
+                             bundle="messages.MicroProfileBundle"
+                             key="microprofile.properties"
                              provider="com.redhat.devtools.intellij.lsp4mp4ij.settings.properties.MicroProfilePropertiesConfigurableProvider"/>
     <applicationConfigurable parentId="MicroProfile"
+                             bundle="messages.MicroProfileBundle"
+                             key="microprofile.java"
                              id="MicroProfileJava"
                              provider="com.redhat.devtools.intellij.lsp4mp4ij.settings.java.MicroProfileJavaConfigurableProvider"/>
     <applicationService id="com.redhat.devtools.intellij.lsp4mp4ij.settings.UserDefinedMicroProfileSettings"

--- a/src/main/resources/META-INF/lsp4ij.xml
+++ b/src/main/resources/META-INF/lsp4ij.xml
@@ -14,6 +14,8 @@
   <extensions defaultExtensionNs="com.intellij">
     <applicationConfigurable groupId="language"
                            id="LanguageServers"
+                           bundle="messages.LanguageServerBundle"
+                           key="language.servers"
                            provider="com.redhat.devtools.intellij.lsp4ij.settings.LanguageServerListConfigurableProvider"/>
     <applicationService id="com.redhat.devtools.intellij.lsp4ij.settings.UserDefinedLanguageServerSettings"
                         serviceImplementation="com.redhat.devtools.intellij.lsp4ij.settings.UserDefinedLanguageServerSettings"/>


### PR DESCRIPTION
fix: No display name is specified for configurable c.r.d.i.lsp4ij.settings.LanguageServerListConfigurable in xml file (#1030)

Fixes #1030