### PR TITLE
feat: Use Qute LS 0.16.0 snapshot.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,8 +183,8 @@ dependencies {
     lsp ("com.redhat.microprofile:com.redhat.quarkus.ls:$quarkusLsVersion") {
         transitive = false
     }
-    implementation "com.redhat.microprofile:com.redhat.qute.ls:$quarkusLsVersion"
-    lsp ("com.redhat.microprofile:com.redhat.qute.ls:$quarkusLsVersion:uber") {
+    implementation "com.redhat.microprofile:com.redhat.qute.ls:$quteLsVersion"
+    lsp ("com.redhat.microprofile:com.redhat.qute.ls:$quteLsVersion:uber") {
         transitive = false
     }
     implementation files(new File(buildDir, 'server')) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,5 @@ jetBrainsChannel=stable
 quarkusVersion=3.1.2.Final
 lsp4mpVersion=0.8.0
 quarkusLsVersion=0.15.0
+quteLsVersion=0.16.0-SNAPSHOT
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
Use Qute LS 0.16.0 snapshot toavoid waiting for release of Qute LS and give the capability to @ia3andy to test new improvement of Qute LS