### PR TITLE
feat: provide a stop process action (dev mode) in the console

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/LanguageServerWrapper.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/LanguageServerWrapper.java
@@ -235,7 +235,12 @@ public class LanguageServerWrapper implements Disposable {
         return folders;
     }
 
-    public synchronized void restart() throws IOException {
+    public synchronized void stopAndDisable() {
+        setEnabled(false);
+        stop();
+    }
+
+    public synchronized void restart() {
         numberOfRestartAttempts = 0;
         setEnabled(true);
         stop();

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/actions/AutoFoldingAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/actions/AutoFoldingAction.java
@@ -34,7 +34,7 @@ public class AutoFoldingAction extends ToggleAction implements DumbAware {
     public AutoFoldingAction(@NotNull final Editor editor) {
         super();
         myEditor = editor;
-        final String message = LanguageServerBundle.message("lsp.console.actions.folding");
+        final String message = LanguageServerBundle.message("action.lsp.console.folding.text");
         getTemplatePresentation().setDescription(message);
         getTemplatePresentation().setText(message);
         getTemplatePresentation().setIcon(AllIcons.Actions.Expandall);

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/LanguageServerExplorer.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/LanguageServerExplorer.java
@@ -25,6 +25,7 @@ import com.redhat.devtools.intellij.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.intellij.lsp4ij.console.LSPConsoleToolWindowPanel;
 import com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.CopyStartServerCommandAction;
 import com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.RestartServerAction;
+import com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.PauseServerAction;
 import com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.StopServerAction;
 import com.redhat.devtools.intellij.lsp4ij.lifecycle.LanguageServerLifecycleManager;
 
@@ -124,10 +125,15 @@ public class LanguageServerExplorer extends SimpleToolWindowPanel implements Dis
                         switch (processTreeNode.getServerStatus()) {
                             case starting:
                             case started:
-                                // Stop language server action
+                                // Stop and disable the language server action
                                 group = new DefaultActionGroup();
                                 AnAction stopServerAction = ActionManager.getInstance().getAction(StopServerAction.ACTION_ID);
                                 group.add(stopServerAction);
+                                if (Boolean.getBoolean("idea.is.internal")) {
+                                    // In dev mode, enable the "Pause" action
+                                    AnAction pauseServerAction = ActionManager.getInstance().getAction(PauseServerAction.ACTION_ID);
+                                    group.add(pauseServerAction);
+                                }
                                 break;
                             case stopping:
                             case stopped:

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/LanguageServerProcessTreeNode.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/LanguageServerProcessTreeNode.java
@@ -98,7 +98,7 @@ public class LanguageServerProcessTreeNode extends DefaultMutableTreeNode {
 
     public Icon getIcon() {
         if (!languageServer.isEnabled()) {
-            return AllIcons.RunConfigurations.TestFailed;
+            return AllIcons.Actions.Cancel;
         }
         boolean hasError = languageServer.getServerError() != null;
         switch (serverStatus) {

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/actions/CopyStartServerCommandAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/actions/CopyStartServerCommandAction.java
@@ -33,11 +33,7 @@ import java.util.stream.Collectors;
  */
 public class CopyStartServerCommandAction extends TreeAction implements DumbAware {
 
-    public static final String ACTION_ID = "com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.CopyStartServerCommandAction";
-
-    public CopyStartServerCommandAction() {
-        super(LanguageServerBundle.message("lsp.console.explorer.actions.copy.command"));
-    }
+    public static final String ACTION_ID = "lsp.console.explorer.copy.command";
 
     @Override
     protected void actionPerformed(@NotNull Tree tree, @NotNull AnActionEvent e) {

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/actions/PauseServerAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/actions/PauseServerAction.java
@@ -21,17 +21,16 @@ import com.redhat.devtools.intellij.lsp4ij.LanguageServerWrapper;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Action to stop the selected language server process and disable it from the language explorer.
+ * Action to stop the selected language server process from the language explorer.
  */
-public class StopServerAction extends TreeAction implements DumbAware {
+public class PauseServerAction extends TreeAction implements DumbAware {
 
-    public static final String ACTION_ID = "lsp.console.explorer.stop";
-
+    public static final String ACTION_ID = "lsp.console.explorer.pause";
     @Override
     protected void actionPerformed(@NotNull Tree tree, @NotNull AnActionEvent e) {
         LanguageServerWrapper languageServer = getSelectedLanguageServer(tree);
         if (languageServer != null) {
-            languageServer.stopAndDisable();
+            languageServer.stop();
         }
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/actions/RestartServerAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/actions/RestartServerAction.java
@@ -29,23 +29,13 @@ import java.io.IOException;
  */
 public class RestartServerAction extends TreeAction implements DumbAware {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RestartServerAction.class);//$NON-NLS-1$
-
-    public static final String ACTION_ID = "com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.RestartServerAction";
-
-    public RestartServerAction() {
-        super(LanguageServerBundle.message("lsp.console.explorer.actions.restart"));
-    }
+    public static final String ACTION_ID = "lsp.console.explorer.restart";
 
     @Override
     protected void actionPerformed(@NotNull Tree tree, @NotNull AnActionEvent e) {
         LanguageServerWrapper languageServer = getSelectedLanguageServer(tree);
         if (languageServer != null) {
-            try {
-                languageServer.restart();
-            } catch (IOException ex) {
-                LOGGER.error("Failed restarting server", ex);
-            }
+            languageServer.restart();
         }
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/actions/TreeAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/actions/TreeAction.java
@@ -30,11 +30,6 @@ import java.awt.*;
  * Base class for Actions processed from the Language Server tree.
  */
 public abstract class TreeAction extends AnAction {
-
-    protected TreeAction(@Nullable @NlsActions.ActionText String text) {
-        super(text);
-    }
-
     public final void actionPerformed(@NotNull AnActionEvent e) {
         Tree tree = getTree(e);
         if (tree == null) {

--- a/src/main/resources/META-INF/lsp4ij.xml
+++ b/src/main/resources/META-INF/lsp4ij.xml
@@ -27,13 +27,16 @@
   </extensions>
 
   <actions resource-bundle="messages.LanguageServerBundle">
-    <action id="com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.RestartServerAction"
+    <action id="lsp.console.explorer.restart"
           class="com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.RestartServerAction"
           icon="AllIcons.Actions.Restart" />
-    <action id="com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.StopServerAction"
+    <action id="lsp.console.explorer.stop"
             class="com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.StopServerAction"
             icon="AllIcons.Actions.Suspend" />
-    <action id="com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.CopyStartServerCommandAction"
+    <action id="lsp.console.explorer.pause"
+            class="com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.PauseServerAction"
+            icon="AllIcons.Actions.Pause" />
+    <action id="lsp.console.explorer.copy.command"
             class="com.redhat.devtools.intellij.lsp4ij.console.explorer.actions.CopyStartServerCommandAction"
             icon="AllIcons.Actions.Copy" />
   </actions>

--- a/src/main/resources/messages/LanguageServerBundle.properties
+++ b/src/main/resources/messages/LanguageServerBundle.properties
@@ -19,10 +19,15 @@ language.server.trace=Trace:
 
 ## LSP console
 lsp.console.title=LSP Consoles
-lsp.console.explorer.actions.restart=Restart
-lsp.console.explorer.actions.stop=Stop
-lsp.console.explorer.actions.copy.command=Copy Start Command
-lsp.console.actions.folding=Collapse/Expand All
+action.lsp.console.explorer.restart.text=Restart
+action.lsp.console.explorer.restart.description=Restart the language server
+action.lsp.console.explorer.stop.text=Stop
+action.lsp.console.explorer.stop.description=Stop and disable the language server
+action.lsp.console.explorer.pause.text=Pause
+action.lsp.console.explorer.pause.description=Pause the language server
+action.lsp.console.explorer.copy.command.text=Copy Start Command
+action.lsp.console.explorer.copy.command.description=Copy the command which starts the language server
+action.lsp.console.folding.text=Collapse/Expand All
 
 ## Dialog
 lsp.create.file.confirm.dialog.title=Create file?


### PR DESCRIPTION
This PR improve the stop action from the LSP explorer console:

![image](https://github.com/redhat-developer/intellij-quarkus/assets/1932211/53f6a179-42d3-44aa-acdf-0f808b8400fc)

 * `Stop `: this action now stop the language server and disable it. To re-enable it you must execute again the Restart action
 * `Pause`: only available in dev mode, it stop the language server process. If you type something in the editor, a new language server (new process) will be restarted (same behavior than the old stop action).