### PR TITLE
feat: mark @BuildStep-annotated methods as implicitly used

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/QuarkusConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/QuarkusConstants.java
@@ -65,6 +65,7 @@ public class QuarkusConstants {
 
     public static final String QUARKUS_ARC_CONFIG_PROPERTIES_DEFAULT_NAMING_STRATEGY = "quarkus.arc.config-properties-default-naming-strategy";
 
+    public static final String QUARKUS_DEPLOYMENT_BUILDSTEP_ANNOTATION = "io.quarkus.deployment.annotations.BuildStep";
 
     public static final String QUARKUS_CORE_PREFIX = "io.quarkus:quarkus-core:";
     public static final String QUARKUS_PREFIX = "quarkus";

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/psi/internal/QuarkusBuildImplicitUsageProvider.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/psi/internal/QuarkusBuildImplicitUsageProvider.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.intellij.quarkus.psi.internal;
+
+import com.intellij.codeInsight.daemon.ImplicitUsageProvider;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.jaxrs.JaxRsConstants;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.restclient.MicroProfileRestClientConstants;
+import org.jetbrains.annotations.NotNull;
+
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils.hasAnyAnnotation;
+import static com.redhat.devtools.intellij.quarkus.QuarkusConstants.QUARKUS_DEPLOYMENT_BUILDSTEP_ANNOTATION;
+
+/**
+ * Automatically declares as used, methods annotated with {@link io.quarkus.deployment.annotations.BuildStep} annotations, such as:
+ * <p>
+ * {@code
+ *     @BuildStep
+ *     AdditionalBeanBuildItem producePrettyTime() {
+ *         return new AdditionalBeanBuildItem(PrettyTimeProducer.class);
+ *     }
+ * }
+ * </p>
+ */
+public class QuarkusBuildImplicitUsageProvider implements ImplicitUsageProvider {
+
+    @Override
+    public boolean isImplicitUsage(@NotNull PsiElement element) {
+        return isImplicitRead(element) || isImplicitWrite(element);
+    }
+
+    @Override
+    public boolean isImplicitRead(@NotNull PsiElement element) {
+        return element instanceof PsiMethod &&
+                !((PsiMethod)element).isConstructor() &&
+                AnnotationUtils.hasAnyAnnotation(element, QUARKUS_DEPLOYMENT_BUILDSTEP_ANNOTATION);
+    }
+
+    @Override
+    public boolean isImplicitWrite(@NotNull PsiElement element) {
+        return false;
+    }
+}

--- a/src/main/resources/META-INF/lsp4ij-quarkus.xml
+++ b/src/main/resources/META-INF/lsp4ij-quarkus.xml
@@ -45,7 +45,7 @@
                         serviceImplementation="com.redhat.devtools.intellij.lsp4mp4ij.settings.UserDefinedMicroProfileSettings"/>
 
     <implicitUsageProvider implementation="com.redhat.devtools.intellij.lsp4mp4ij.psi.core.JavaEEImplicitUsageProvider"/>
-
+    <implicitUsageProvider implementation="com.redhat.devtools.intellij.quarkus.psi.internal.QuarkusBuildImplicitUsageProvider"/>
     <!-- Quarkus -->
     <lang.documentationProvider id="LSPTextHoverProperties" language="Properties" implementationClass="com.redhat.devtools.intellij.lsp4ij.operations.hover.LSPTextHover" order="first"/>
     <externalAnnotator language="Properties"


### PR DESCRIPTION
fixes #1095 

Before:
<img width="913" alt="Screenshot 2023-08-10 at 15 32 45" src="https://github.com/redhat-developer/intellij-quarkus/assets/148698/463b26d3-4daf-4395-bba7-1395d3b4e174">

After:
<img width="1403" alt="Screenshot 2023-08-10 at 16 04 10" src="https://github.com/redhat-developer/intellij-quarkus/assets/148698/2997dd8d-e6cc-4b7c-ae3e-ee4e661f9172">

@gastaldi  IJ automatically finds usages in .dot file
