### PR TITLE
fix: prevent StackOverflowError in QuarkusConfigMappingProvider.populateConfigObject

### DIFF
--- a/src/main/java/com/redhat/microprofile/psi/internal/quarkus/core/properties/QuarkusConfigMappingProvider.java
+++ b/src/main/java/com/redhat/microprofile/psi/internal/quarkus/core/properties/QuarkusConfigMappingProvider.java
@@ -214,7 +214,7 @@ public class QuarkusConfigMappingProvider extends AbstractAnnotationTypeReferenc
 					PsiQuarkusUtils.updateConverterKinds(metadata, method, enclosedType);
 				} else {
 					// Other type (App, etc)
-					populateConfigObject(returnType, propertyName, extensionName, new HashSet<>(),
+					populateConfigObject(returnType, propertyName, extensionName, typesAlreadyProcessed,
 							configMappingAnnotation, collector);
 				}
 			}


### PR DESCRIPTION
Fixes #1110 