### PR TITLE
feat: support for excluding properties from validation

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/AbstractDelegateInspectionWithExcludedProperties.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/AbstractDelegateInspectionWithExcludedProperties.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
+
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.codeInspection.ui.InspectionOptionsPanel;
+import com.intellij.codeInspection.ui.ListEditForm;
+import com.redhat.devtools.intellij.lsp4mp4ij.MicroProfileBundle;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * No-op {@link LocalInspectionTool} used as a basis for mapping properties inspection severities to matching LSP severities.
+ * Adds the possibility to define excluded properties.
+ */
+public abstract class AbstractDelegateInspectionWithExcludedProperties extends LocalInspectionTool {
+
+    public final @NotNull List<String> excludeList = new ArrayList<>();
+
+    public JComponent createOptionsPanel() {
+        InspectionOptionsPanel panel = new InspectionOptionsPanel();
+
+        var injectionListTable = new ListEditForm("", MicroProfileBundle.message("microprofile.properties.validation.excluded.properties"), excludeList);
+
+        panel.addGrowing(injectionListTable.getContentPanel());
+
+        return panel;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesUnassignedInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesUnassignedInspection.java
@@ -14,8 +14,8 @@
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
 
 /**
- * Dummy inspection for expression values in Microprofile properties files
+ * Dummy inspection for unknown properties in Microprofile properties files
  */
-public class MicroProfilePropertiesExpressionsInspection extends AbstractDelegateInspectionWithExcludedProperties {
-    public static final String ID = getShortName(MicroProfilePropertiesExpressionsInspection.class.getSimpleName());
+public class MicroProfilePropertiesUnassignedInspection extends AbstractDelegateInspectionWithExcludedProperties {
+    public static final String ID = getShortName(MicroProfilePropertiesUnassignedInspection.class.getSimpleName());
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesUnknownInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesUnknownInspection.java
@@ -13,9 +13,16 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
 
+import java.util.Arrays;
+
 /**
  * Dummy inspection for unknown properties in Microprofile properties files
  */
-public class MicroProfilePropertiesUnknownInspection extends AbstractDelegateInspection {
+public class MicroProfilePropertiesUnknownInspection extends AbstractDelegateInspectionWithExcludedProperties {
     public static final String ID = getShortName(MicroProfilePropertiesUnknownInspection.class.getSimpleName());
+
+    public MicroProfilePropertiesUnknownInspection() {
+        super();
+        excludeList.addAll(Arrays.asList("*/mp-rest/providers/*/priority", "mp.openapi.schema.*", "kafka-streams.*", "camel.*"));
+    }
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/settings/UserDefinedMicroProfileSettings.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/settings/UserDefinedMicroProfileSettings.java
@@ -142,18 +142,29 @@ public class UserDefinedMicroProfileSettings implements PersistentStateComponent
         tools.put("validation", validation);
         validation.put("enabled", isValidationEnabled());
         validation.put("syntax", getSeverityNode(inspectionsInfo.syntaxSeverity()));
-        validation.put("unknown", getSeverityNode(inspectionsInfo.unknownSeverity()));
         validation.put("duplicate", getSeverityNode(inspectionsInfo.duplicateSeverity()));
         validation.put("value", getSeverityNode(inspectionsInfo.valueSeverity()));
         validation.put("required", getSeverityNode(inspectionsInfo.requiredSeverity()));
         validation.put("expression", getSeverityNode(inspectionsInfo.expressionSeverity()));
+
+        validation.put("unknown", getSeverityAndExclusions(inspectionsInfo.unknownSeverity(), inspectionsInfo.getExcludedUnknownProperties()));
+        validation.put("unassigned", getSeverityAndExclusions(inspectionsInfo.unassignedSeverity(), inspectionsInfo.getExcludedUnassignedProperties()));
+
         return settings;
+    }
+
+    private Map<String, Object> getSeverityAndExclusions(DiagnosticSeverity severity, List<String> exclusions) {
+        Map<String, Object> inspection = new HashMap<>();
+        inspection.put("severity", SeverityMapping.toString(severity));
+        if (exclusions != null && !exclusions.isEmpty()) {
+            inspection.put("excluded", exclusions);
+        }
+        return inspection;
     }
 
     private Map<String, String> getSeverityNode(DiagnosticSeverity severity) {
         return Collections.singletonMap("severity", SeverityMapping.toString(severity));
     }
-
 
     public static class MyState {
 

--- a/src/main/resources/META-INF/lsp4ij-quarkus.xml
+++ b/src/main/resources/META-INF/lsp4ij-quarkus.xml
@@ -113,6 +113,15 @@
             enabledByDefault="true"
             level="ERROR"
             implementationClass="com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections.MicroProfilePropertiesExpressionsInspection"/>
+    <localInspection
+            language="JAVA"
+            bundle="messages.MicroProfileBundle"
+            key="microprofile.properties.validation.unassigned"
+            groupPathKey="microprofile.inspection.group.name"
+            groupKey="microprofile.java.inspection.group.name"
+            enabledByDefault="true"
+            level="WARNING"
+            implementationClass="com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections.MicroProfilePropertiesUnassignedInspection"/>
   </extensions>
 
 </idea-plugin>

--- a/src/main/resources/inspectionDescriptions/MicroProfilePropertiesUnassigned.html
+++ b/src/main/resources/inspectionDescriptions/MicroProfilePropertiesUnassigned.html
@@ -1,0 +1,20 @@
+<html>
+<body>
+Reports properties in <code>.java</code> files unassigned from properties file.
+<p><b>Example:</b></p>
+<pre><code>
+@ConfigProperty(name="missing.from.properties")
+private String myConfig;
+</code></pre>
+<div style="border-left: 6px solid #e7af18; display: block; padding:5px">
+    <p style="margin:5px">
+        &#9888; This inspection is used to configure the <b>Tools for MicroProfile</b> server in <a href="settings://LanguageServers"> Settings | Languages &amp; Frameworks | Language Servers</a>.<br/><br/>
+        Consequently, some limitations apply:
+    </p>
+    <ul>
+        <li><i>Scope, Severity and Highlighting</i> are ignored</li>
+        <li><i>Excluded properties</i> are respected</li>
+    </ul>
+</div>
+</body>
+</html>

--- a/src/main/resources/messages/MicroProfileBundle.properties
+++ b/src/main/resources/messages/MicroProfileBundle.properties
@@ -36,3 +36,4 @@ microprofile.properties.validation.unassigned=Unassigned properties
 microprofile.java=Java
 microprofile.java.title=MicroProfile configuration in Java files
 microprofile.java.codeLens.url.enabled=Show Rest endpoint URL as inlay hint?
+microprofile.properties.validation.excluded.properties=Excluded properties. Patterns can be used ('*' = any string, '?' = any character).


### PR DESCRIPTION
Starting with excluded unknown properties
<img width="1434" alt="Screenshot 2023-08-31 at 15 47 10" src="https://github.com/redhat-developer/intellij-quarkus/assets/148698/739b9a6e-b098-4e5f-bdcb-c19b40146517">

Unassigned properties in Java files
<img width="1434" alt="Screenshot 2023-08-31 at 16 05 26" src="https://github.com/redhat-developer/intellij-quarkus/assets/148698/a58fceb6-d855-44d0-a491-be7553f85e5f">



