### PR TITLE
build: add quarkus icon for IDEA project

### DIFF
--- a/.idea/icon.svg
+++ b/.idea/icon.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 1024 1024" style="enable-background:new 0 0 1024 1024;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#4695EB;}
+	.st1{fill:#FF004A;}
+	.st2{fill:#FFFFFF;}
+</style>
+<rect width="1024" height="1024"/>
+<polygon class="st0" points="657.3,205.9 512,289.8 657.3,373.7 "/>
+<polygon class="st1" points="366.7,205.9 366.7,373.7 512,289.8 "/>
+<polygon class="st2" points="657.3,373.7 512,289.8 366.7,373.7 512,457.6 "/>
+<polygon class="st0" points="213.4,471.3 358.8,555.2 358.8,387.4 "/>
+<polygon class="st1" points="358.8,723 504.1,639.1 358.8,555.2 "/>
+<polygon class="st2" points="358.8,387.4 358.8,555.2 504.1,639.1 504.1,471.3 "/>
+<polygon class="st0" points="665.2,723 665.2,555.2 519.9,639.1 "/>
+<polygon class="st1" points="810.6,471.3 665.2,387.4 665.2,555.2 "/>
+<polygon class="st2" points="519.9,639.1 665.2,555.2 665.2,387.4 519.9,471.3 "/>
+<path class="st0" d="M827.4,40H196.6C110.5,40,40,110.5,40,196.6v630.8C40,913.5,110.5,984,196.6,984h432L512,700.8l-84.6,178.8
+	H196.6c-28.3,0-52.2-23.9-52.2-52.2V196.6c0-28.3,23.9-52.2,52.2-52.2h630.8c28.3,0,52.2,23.9,52.2,52.2v630.8
+	c0,28.3-23.9,52.2-52.2,52.2H690.5l43,104.4h93.9c86.1,0,156.6-70.5,156.6-156.6V196.6C984,110.5,913.5,40,827.4,40z"/>
+</svg>


### PR DESCRIPTION
Super important PR to customize the intellij-quarkus icon when opening in IDEA:

<img width="543" alt="Screenshot 2023-09-07 at 11 55 56" src="https://github.com/redhat-developer/intellij-quarkus/assets/148698/42317e47-1dd5-4d59-bf2c-28db47523d13">
<img width="468" alt="Screenshot 2023-09-07 at 11 56 20" src="https://github.com/redhat-developer/intellij-quarkus/assets/148698/92c11d16-a016-4b2c-9e48-a907310fc272">
