### PR TITLE
feat: GraphQL improvements

### DIFF
--- a/projects/lsp4mp/projects/maven/microprofile-graphql/pom.xml
+++ b/projects/lsp4mp/projects/maven/microprofile-graphql/pom.xml
@@ -40,6 +40,11 @@
         <version>1.0.2</version>
     </dependency>
     <dependency>
+      <groupId>io.smallrye</groupId>
+      <artifactId>smallrye-graphql-api</artifactId>
+      <version>2.4.0</version>
+    </dependency>
+    <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>1.7.30</version>

--- a/projects/lsp4mp/projects/maven/microprofile-graphql/src/main/java/io/openliberty/graphql/sample/Optimistic.java
+++ b/projects/lsp4mp/projects/maven/microprofile-graphql/src/main/java/io/openliberty/graphql/sample/Optimistic.java
@@ -1,0 +1,15 @@
+package io.openliberty.graphql.sample;
+
+import io.smallrye.graphql.api.Directive;
+import io.smallrye.graphql.api.DirectiveLocation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Directive(on = {DirectiveLocation.ENUM})
+@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Optimistic {
+}

--- a/projects/lsp4mp/projects/maven/microprofile-graphql/src/main/java/io/openliberty/graphql/sample/WeatherService.java
+++ b/projects/lsp4mp/projects/maven/microprofile-graphql/src/main/java/io/openliberty/graphql/sample/WeatherService.java
@@ -36,6 +36,7 @@ public class WeatherService {
 
 
     @Query
+    @Optimistic
     public Conditions currentConditions(@Name("location") String location) throws UnknownLocationException {
         if ("nowhere".equalsIgnoreCase(location)) {
             throw new UnknownLocationException(location);
@@ -45,7 +46,7 @@ public class WeatherService {
 
     @DenyAll
     @Query
-    public List<Conditions> currentConditionsList(@Name("locations") List<String> locations)
+    public List<Conditions> currentConditionsList(@Optimistic @Name("locations") List<String> locations)
         throws UnknownLocationException, GraphQLException {
 
         List<Conditions> allConditions = new LinkedList<>();
@@ -69,7 +70,7 @@ public class WeatherService {
         return cleared;
     }
 
-    public double wetBulbTempF(@Source @Name("conditions") Conditions conditions) {
+    public double wetBulbTempF(@Source @Name("conditions") @Optimistic Conditions conditions) {
         // TODO: pretend like this is a really expensive operation
         System.out.println("wetBulbTempF for location " + conditions.getLocation());
         return conditions.getTemperatureF() - 3.0;

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/graphql/MicroProfileGraphQLConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/graphql/MicroProfileGraphQLConstants.java
@@ -22,9 +22,11 @@ public class MicroProfileGraphQLConstants {
     }
 
     public static final String QUERY_ANNOTATION = "org.eclipse.microprofile.graphql.Query";
-
     public static final String MUTATION_ANNOTATION = "org.eclipse.microprofile.graphql.Mutation";
-
+    public static final String SUBSCRIPTION_ANNOTATION = "org.eclipse.microprofile.graphql.Subscription";
+    public static final String GRAPHQL_API_ANNOTATION = "org.eclipse.microprofile.graphql.GraphQLApi";
+    public static final String UNION_ANNOTATION = "io.smallrye.graphql.api.Union";
+    public static final String DIRECTIVE_ANNOTATION = "io.smallrye.graphql.api.Directive";
     public static final String DIAGNOSTIC_SOURCE = "microprofile-graphql";
 
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/graphql/TypeSystemDirectiveLocation.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/graphql/TypeSystemDirectiveLocation.java
@@ -11,21 +11,23 @@
 * Contributors:
 *     Red Hat Inc. - initial API and implementation
 *******************************************************************************/
-package com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.graphql.java;
-
-import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.java.diagnostics.IJavaErrorCode;
+package com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.graphql;
 
 /**
- * MicroProfile GraphQL diagnostics error code.
+ * GraphQL schema element types - used for declaring the allowed
+ * placement of directives in a GraphQL schema.
+ * See http://spec.graphql.org/draft/#TypeSystemDirectiveLocation
  */
-public enum MicroProfileGraphQLErrorCode implements IJavaErrorCode {
-
-	WRONG_DIRECTIVE_PLACEMENT
-	;
-
-	@Override
-	public String getCode() {
-		return name();
-	}
-
+public enum TypeSystemDirectiveLocation {
+    SCHEMA,
+    SCALAR,
+    OBJECT,
+    FIELD_DEFINITION,
+    ARGUMENT_DEFINITION,
+    INTERFACE,
+    UNION,
+    ENUM,
+    ENUM_VALUE,
+    INPUT_OBJECT,
+    INPUT_FIELD_DEFINITION
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/graphql/java/MicroProfileGraphQLASTValidator.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/graphql/java/MicroProfileGraphQLASTValidator.java
@@ -14,44 +14,176 @@
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.graphql.java;
 
 
+import java.text.MessageFormat;
+import java.util.Arrays;
 import java.util.logging.Logger;
 
+import com.intellij.lang.jvm.JvmMethod;
+import com.intellij.lang.jvm.types.JvmArrayType;
+import com.intellij.lang.jvm.types.JvmPrimitiveType;
+import com.intellij.lang.jvm.types.JvmReferenceType;
+import com.intellij.lang.jvm.types.JvmType;
+import com.intellij.lang.jvm.types.JvmTypeVisitor;
+import com.intellij.lang.jvm.types.JvmWildcardType;
 import com.intellij.openapi.module.Module;
 import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.PsiAnnotationMemberValue;
+import com.intellij.psi.PsiArrayInitializerMemberValue;
+import com.intellij.psi.PsiArrayType;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiClassType;
+import com.intellij.psi.PsiEnumConstant;
+import com.intellij.psi.PsiField;
+import com.intellij.psi.PsiJvmModifiersOwner;
 import com.intellij.psi.PsiMethod;
+import com.intellij.psi.PsiParameter;
+import com.intellij.psi.PsiParameterList;
 import com.intellij.psi.PsiType;
+import com.intellij.psi.impl.source.PsiClassReferenceType;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.java.diagnostics.JavaDiagnosticsContext;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.java.validators.JavaASTValidator;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.PsiTypeUtils;
-import org.eclipse.lsp4j.DiagnosticSeverity;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.graphql.MicroProfileGraphQLConstants;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.graphql.TypeSystemDirectiveLocation;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.jetbrains.annotations.NotNull;
 
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils.getAnnotation;
 import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils.isMatchAnnotation;
 
 /**
  * Diagnostics for microprofile-graphql.
  *
+ * TODO: We currently don't check directives on input/output objects and their properties, because
+ * it's not trivial to determine whether a class is used as an input, or an output, or both. That
+ * will possibly require building the whole GraphQL schema on-the-fly, which might be too expensive.
+ *
  * @see https://download.eclipse.org/microprofile/microprofile-graphql-1.0/microprofile-graphql.html
  */
 public class MicroProfileGraphQLASTValidator extends JavaASTValidator {
 
-	private static final Logger LOGGER = Logger.getLogger(MicroProfileGraphQLASTValidator.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(MicroProfileGraphQLASTValidator.class.getName());
 
-	@Override
-	public boolean isAdaptedForDiagnostics(JavaDiagnosticsContext context) {
-		Module javaProject = context.getJavaProject();
-		// Check if microprofile-graphql is on the path
-		return PsiTypeUtils.findType(javaProject, MicroProfileGraphQLConstants.QUERY_ANNOTATION) != null;
-	}
+    private static final String WRONG_DIRECTIVE_PLACEMENT = "Directive ''{0}'' is not allowed on element type ''{1}''";
 
-	@Override
-	public void visitMethod(PsiMethod node) {
-		validateMethod(node);
-		super.visitMethod(node);
-	}
+    @Override
+    public boolean isAdaptedForDiagnostics(JavaDiagnosticsContext context) {
+        Module javaProject = context.getJavaProject();
+        // Check if microprofile-graphql is on the path
+        return PsiTypeUtils.findType(javaProject, MicroProfileGraphQLConstants.QUERY_ANNOTATION) != null;
+    }
 
-	private void validateMethod(PsiMethod node) {
+    @Override
+    public void visitMethod(PsiMethod node) {
+        validateDirectivesOnMethod(node);
+        super.visitMethod(node);
+    }
 
-	}
+    @Override
+    public void visitClass(PsiClass node) {
+        validateDirectivesOnClass(node);
+        super.visitClass(node);
+    }
+
+
+    private void validateDirectivesOnMethod(PsiMethod node) {
+        for (PsiAnnotation annotation : node.getAnnotations()) {
+            // a query/mutation/subscription may only have directives allowed on FIELD_DEFINITION
+            if (isMatchAnnotation(annotation, MicroProfileGraphQLConstants.QUERY_ANNOTATION) ||
+                    isMatchAnnotation(annotation, MicroProfileGraphQLConstants.MUTATION_ANNOTATION) ||
+                    isMatchAnnotation(annotation, MicroProfileGraphQLConstants.SUBSCRIPTION_ANNOTATION)) {
+                validateDirectives(node, TypeSystemDirectiveLocation.FIELD_DEFINITION);
+            }
+        }
+        // any parameter may only have directives allowed on ARGUMENT_DEFINITION
+        for (PsiParameter parameter : node.getParameterList().getParameters()) {
+            validateDirectives(parameter, TypeSystemDirectiveLocation.ARGUMENT_DEFINITION);
+        }
+    }
+
+    private void validateDirectivesOnClass(PsiClass node) {
+        // a class with @GraphQLApi may only have directives allowed on SCHEMA
+        if(getAnnotation(node, MicroProfileGraphQLConstants.GRAPHQL_API_ANNOTATION) != null) {
+            validateDirectives(node, TypeSystemDirectiveLocation.SCHEMA);
+        }
+        // if an interface has a `@Union` annotation, it may only have directives allowed on UNION
+        // otherwise it may only have directives allowed on INTERFACE
+        if (node.isInterface()) {
+            if(getAnnotation(node, MicroProfileGraphQLConstants.UNION_ANNOTATION) != null) {
+                validateDirectives(node, TypeSystemDirectiveLocation.UNION);
+            } else {
+                validateDirectives(node, TypeSystemDirectiveLocation.INTERFACE);
+            }
+        }
+        // an enum may only have directives allowed on ENUM
+        if (node.isEnum()) {
+            validateDirectives(node, TypeSystemDirectiveLocation.ENUM);
+            // enum values may only have directives allowed on ENUM_VALUE
+            for (PsiField field : node.getFields()) {
+                if(field instanceof PsiEnumConstant) {
+                    validateDirectives(field, TypeSystemDirectiveLocation.ENUM_VALUE);
+                }
+            }
+        }
+    }
+
+    private void validateDirectives(PsiJvmModifiersOwner node, TypeSystemDirectiveLocation actualLocation) {
+        directiveLoop:
+        for (PsiAnnotation annotation : node.getAnnotations()) {
+            PsiClass directiveDeclaration = getDirectiveDeclaration(annotation);
+            if (directiveDeclaration != null) {
+                LOGGER.severe("Checking directive: " + annotation.getQualifiedName() + " on node: " + node + " (location type = " + actualLocation.name() + ")");
+                PsiArrayInitializerMemberValue allowedLocations = (PsiArrayInitializerMemberValue) directiveDeclaration
+                        .getAnnotation(MicroProfileGraphQLConstants.DIRECTIVE_ANNOTATION)
+                        .findAttributeValue("on");
+                if (allowedLocations != null) {
+                    for (PsiAnnotationMemberValue initializer : allowedLocations.getInitializers()) {
+                        String allowedLocation = initializer.getText().substring(initializer.getText().indexOf(".") + 1);
+                        if (allowedLocation.equals(actualLocation.name())) {
+                            // ok, this directive is allowed on this element type
+                            continue directiveLoop;
+                        }
+                    }
+
+                    String message = MessageFormat.format(WRONG_DIRECTIVE_PLACEMENT, directiveDeclaration.getQualifiedName(), actualLocation.name());
+                    super.addDiagnostic(message,
+                            MicroProfileGraphQLConstants.DIAGNOSTIC_SOURCE,
+                            annotation,
+                            MicroProfileGraphQLErrorCode.WRONG_DIRECTIVE_PLACEMENT,
+                            DiagnosticSeverity.Error);
+                }
+            }
+        }
+
+    }
+
+    // If this annotation is not a directive at all, returns null.
+    // If this annotation is a directive, returns its annotation class.
+    // If this annotation is a container of a repeatable directive, returns the annotation class of the directive (not the container).
+    private PsiClass getDirectiveDeclaration(PsiAnnotation annotation) {
+        PsiClass declaration = PsiTypeUtils.findType(getContext().getJavaProject(), annotation.getQualifiedName());
+        if (declaration == null) {
+            return null;
+        }
+        if (declaration.getAnnotation(MicroProfileGraphQLConstants.DIRECTIVE_ANNOTATION) != null) {
+            return declaration;
+        }
+        // check whether this is a container of repeatable directives
+        PsiMethod[] annoParams = declaration.findMethodsByName("value", false);
+        for (PsiMethod annoParam : annoParams) {
+            if (annoParam.getReturnType() instanceof PsiArrayType) {
+                PsiType componentType = ((PsiArrayType) annoParam.getReturnType()).getComponentType();
+                if (componentType instanceof PsiClassReferenceType) {
+                    PsiClass directiveDeclaration = PsiTypeUtils.findType(getContext().getJavaProject(),
+                            ((PsiClassReferenceType) componentType).getReference().getQualifiedName());
+                    if (directiveDeclaration != null && directiveDeclaration.getAnnotation(MicroProfileGraphQLConstants.DIRECTIVE_ANNOTATION) != null) {
+                        return directiveDeclaration;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
 
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/graphql/java/MicroProfileGraphQLASTValidator.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/graphql/java/MicroProfileGraphQLASTValidator.java
@@ -37,8 +37,6 @@ public class MicroProfileGraphQLASTValidator extends JavaASTValidator {
 
 	private static final Logger LOGGER = Logger.getLogger(MicroProfileGraphQLASTValidator.class.getName());
 
-	private static final String NO_VOID_MESSAGE = "Methods annotated with microprofile-graphql's `@Query` cannot have 'void' as a return type.";
-	private static final String NO_VOID_MUTATION_MESSAGE = "Methods annotated with microprofile-graphql's `@Mutation` cannot have 'void' as a return type.";
 	@Override
 	public boolean isAdaptedForDiagnostics(JavaDiagnosticsContext context) {
 		Module javaProject = context.getJavaProject();
@@ -53,26 +51,7 @@ public class MicroProfileGraphQLASTValidator extends JavaASTValidator {
 	}
 
 	private void validateMethod(PsiMethod node) {
-		// ignore constructors, and non-void methods for now, it's faster than iterating through all annotations
-		if (node.getReturnTypeElement() == null ||
-			!PsiType.VOID.equals(node.getReturnType())) {
-			return;
-		}
-		for (PsiAnnotation annotation : node.getAnnotations()) {
-			if (isMatchAnnotation(annotation, MicroProfileGraphQLConstants.QUERY_ANNOTATION) ) {
-				super.addDiagnostic(NO_VOID_MESSAGE, //
-						MicroProfileGraphQLConstants.DIAGNOSTIC_SOURCE, //
-						node.getReturnTypeElement(), //
-						MicroProfileGraphQLErrorCode.NO_VOID_QUERIES, //
-						DiagnosticSeverity.Error);
-			} else if (isMatchAnnotation(annotation, MicroProfileGraphQLConstants.MUTATION_ANNOTATION)) {
-				super.addDiagnostic(NO_VOID_MUTATION_MESSAGE, //
-						MicroProfileGraphQLConstants.DIAGNOSTIC_SOURCE, //
-						node.getReturnTypeElement(), //
-						MicroProfileGraphQLErrorCode.NO_VOID_MUTATIONS, //
-						DiagnosticSeverity.Error);
-			}
-		}
+
 	}
 
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/graphql/java/MicroProfileGraphQLErrorCode.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/graphql/java/MicroProfileGraphQLErrorCode.java
@@ -20,6 +20,8 @@ import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.java.diagnostics.IJavaErr
  */
 public enum MicroProfileGraphQLErrorCode implements IJavaErrorCode {
 
+	NO_VOID_QUERIES,
+	NO_VOID_MUTATIONS,
 	WRONG_DIRECTIVE_PLACEMENT
 	;
 

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/graphql/java/MicroProfileGraphQLErrorCode.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/graphql/java/MicroProfileGraphQLErrorCode.java
@@ -20,8 +20,6 @@ import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.java.diagnostics.IJavaErr
  */
 public enum MicroProfileGraphQLErrorCode implements IJavaErrorCode {
 
-	NO_VOID_QUERIES,
-	NO_VOID_MUTATIONS
 	;
 
 	@Override

--- a/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/graphql/java/MicroProfileGraphQLValidationTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/graphql/java/MicroProfileGraphQLValidationTest.java
@@ -13,11 +13,57 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.graphql.java;
 
+import com.intellij.openapi.module.Module;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.LSP4MPMavenModuleImportingTestCase;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileMavenProjectName;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.graphql.MicroProfileGraphQLConstants;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.graphql.java.MicroProfileGraphQLErrorCode;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4mp.commons.DocumentFormat;
+import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsParams;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileForJavaAssert.*;
+
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileForJavaAssert.getFileUri;
 
 /**
  * Tests for {@link com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.graphql.java.MicroProfileGraphQLASTValidator}.
  */
 public class MicroProfileGraphQLValidationTest extends LSP4MPMavenModuleImportingTestCase {
+
+    @Test
+    public void testIncorrectDirectivePlacement() throws Exception {
+        Module javaProject = loadMavenProject(MicroProfileMavenProjectName.microprofile_graphql);
+        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
+
+        MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
+        String javaFileUri = getFileUri("/src/main/java/io/openliberty/graphql/sample/WeatherService.java", javaProject);
+        diagnosticsParams.setUris(Collections.singletonList(javaFileUri));
+        diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
+
+        Diagnostic d1 = d(38, 4, 15,
+                "Directive 'io.openliberty.graphql.sample.Optimistic' is not allowed on element type 'FIELD_DEFINITION'",
+                DiagnosticSeverity.Error, MicroProfileGraphQLConstants.DIAGNOSTIC_SOURCE,
+                MicroProfileGraphQLErrorCode.WRONG_DIRECTIVE_PLACEMENT);
+
+        Diagnostic d2 = d(48, 50, 61,
+                "Directive 'io.openliberty.graphql.sample.Optimistic' is not allowed on element type 'ARGUMENT_DEFINITION'",
+                DiagnosticSeverity.Error, MicroProfileGraphQLConstants.DIAGNOSTIC_SOURCE,
+                MicroProfileGraphQLErrorCode.WRONG_DIRECTIVE_PLACEMENT);
+
+        Diagnostic d3 = d(72, 59, 70,
+                "Directive 'io.openliberty.graphql.sample.Optimistic' is not allowed on element type 'ARGUMENT_DEFINITION'",
+                DiagnosticSeverity.Error, MicroProfileGraphQLConstants.DIAGNOSTIC_SOURCE,
+                MicroProfileGraphQLErrorCode.WRONG_DIRECTIVE_PLACEMENT);
+
+        assertJavaDiagnostics(diagnosticsParams, utils,
+                d1, d2, d3);
+    }
 
 }

--- a/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/graphql/java/MicroProfileGraphQLValidationTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/graphql/java/MicroProfileGraphQLValidationTest.java
@@ -13,49 +13,11 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.graphql.java;
 
-import com.intellij.openapi.module.Module;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.LSP4MPMavenModuleImportingTestCase;
-import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileMavenProjectName;
-import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
-import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
-import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.graphql.MicroProfileGraphQLConstants;
-import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.graphql.java.MicroProfileGraphQLErrorCode;
-import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.DiagnosticSeverity;
-import org.eclipse.lsp4mp.commons.DocumentFormat;
-import org.eclipse.lsp4mp.commons.MicroProfileJavaDiagnosticsParams;
-import org.junit.Test;
-
-import java.util.Collections;
-
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileForJavaAssert.*;
 
 /**
  * Tests for {@link com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.graphql.java.MicroProfileGraphQLASTValidator}.
  */
 public class MicroProfileGraphQLValidationTest extends LSP4MPMavenModuleImportingTestCase {
 
-    @Test
-    public void testVoidMethods() throws Exception {
-        Module javaProject = loadMavenProject(MicroProfileMavenProjectName.microprofile_graphql);
-        IPsiUtils utils = PsiUtilsLSImpl.getInstance(myProject);
-
-        MicroProfileJavaDiagnosticsParams diagnosticsParams = new MicroProfileJavaDiagnosticsParams();
-        String javaFileUri = getFileUri("/src/main/java/io/openliberty/graphql/sample/WeatherService.java", javaProject);
-        diagnosticsParams.setUris(Collections.singletonList(javaFileUri));
-        diagnosticsParams.setDocumentFormat(DocumentFormat.Markdown);
-
-        Diagnostic d1 = d(89, 11, 15,
-                "Methods annotated with microprofile-graphql's `@Query` cannot have 'void' as a return type.",
-                DiagnosticSeverity.Error, MicroProfileGraphQLConstants.DIAGNOSTIC_SOURCE,
-                MicroProfileGraphQLErrorCode.NO_VOID_QUERIES);
-
-        Diagnostic d2 = d(93, 11, 15,
-                "Methods annotated with microprofile-graphql's `@Mutation` cannot have 'void' as a return type.",
-                DiagnosticSeverity.Error, MicroProfileGraphQLConstants.DIAGNOSTIC_SOURCE,
-                MicroProfileGraphQLErrorCode.NO_VOID_MUTATIONS);
-
-        assertJavaDiagnostics(diagnosticsParams, utils, //
-                d1, d2);
-    }
 }


### PR DESCRIPTION
- Remove the check that forbids returning `void` from GraphQL operations. This is legal in recent Quarkus versions.
- Add some checks for the correct placement of GraphQL directives.