### PR TITLE
feat: add command to update Qute configuration from Qute LS

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/inspections/AbstractDelegateInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/inspections/AbstractDelegateInspection.java
@@ -11,13 +11,12 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
+package com.redhat.devtools.intellij.lsp4ij.inspections;
 
-import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspection;
+import com.intellij.codeInspection.LocalInspectionTool;
 
 /**
- * Dummy inspection for property syntax errors in Microprofile properties files
+ * No-op {@link LocalInspectionTool} used as a basis for mapping inspection severities to matching LSP severities.
  */
-public class MicroProfilePropertiesSyntaxInspection extends AbstractDelegateInspection {
-    public static final String ID = getShortName(MicroProfilePropertiesSyntaxInspection.class.getSimpleName());
+public abstract class AbstractDelegateInspection extends LocalInspectionTool {
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/inspections/AbstractDelegateInspectionWithExclusions.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/inspections/AbstractDelegateInspectionWithExclusions.java
@@ -11,12 +11,11 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
+package com.redhat.devtools.intellij.lsp4ij.inspections;
 
 import com.intellij.codeInspection.LocalInspectionTool;
 import com.intellij.codeInspection.ui.InspectionOptionsPanel;
 import com.intellij.codeInspection.ui.ListEditForm;
-import com.redhat.devtools.intellij.lsp4mp4ij.MicroProfileBundle;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -24,17 +23,27 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * No-op {@link LocalInspectionTool} used as a basis for mapping properties inspection severities to matching LSP severities.
- * Adds the possibility to define excluded properties.
+ * Base {@link LocalInspectionTool} providing the possibility to define exclusions.
  */
-public abstract class AbstractDelegateInspectionWithExcludedProperties extends LocalInspectionTool {
+public abstract class AbstractDelegateInspectionWithExclusions extends LocalInspectionTool {
 
+    private final String exclusionsLabel;
+
+    /**
+     * Inspection constructor
+     * @param exclusionsLabel the label to use for the exclusion component in the options panel
+     */
+    public AbstractDelegateInspectionWithExclusions(@NotNull String exclusionsLabel) {
+        this.exclusionsLabel = exclusionsLabel;
+    }
+
+    //Field is public, so it can be serialized as XML
     public final @NotNull List<String> excludeList = new ArrayList<>();
 
     public JComponent createOptionsPanel() {
         InspectionOptionsPanel panel = new InspectionOptionsPanel();
 
-        var injectionListTable = new ListEditForm("", MicroProfileBundle.message("microprofile.properties.validation.excluded.properties"), excludeList);
+        var injectionListTable = new ListEditForm("", exclusionsLabel, excludeList);
 
         panel.addGrowing(injectionListTable.getContentPanel());
 

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/ui/components/InspectionHyperlink.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/ui/components/InspectionHyperlink.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.intellij.lsp4ij.ui.components;
+
+import com.intellij.ide.DataManager;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.options.ex.Settings;
+import com.intellij.openapi.util.NlsContexts;
+import com.intellij.profile.codeInspection.ui.ErrorsConfigurable;
+import com.intellij.ui.HyperlinkLabel;
+import com.redhat.devtools.intellij.lsp4mp4ij.MicroProfileBundle;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.event.HyperlinkEvent;
+
+/**
+ * HyperlinkLabel that opens an inspection settings page
+ */
+public class InspectionHyperlink extends HyperlinkLabel {
+
+    /**
+     * Creates a new hyperlink to an inspection settings page
+     * @param label the hyperlink label
+     * @param inspectionGroupPath the group path to open in the inspections settings
+     */
+    public InspectionHyperlink(@NotNull @NlsContexts.LinkLabel String label, @NotNull String inspectionGroupPath) {
+        super(label);
+        addHyperlinkListener(e -> {
+            if (HyperlinkEvent.EventType.ACTIVATED.equals(e.getEventType())) {
+                @NotNull DataContext dataContext = DataManager.getInstance().getDataContext(this);
+                @Nullable Settings settings = Settings.KEY.getData(dataContext);
+                if (settings != null) {
+                    @Nullable ErrorsConfigurable inspections = settings.find(ErrorsConfigurable.class);
+                    if (inspections != null) {
+                        settings.select(inspections).doWhenDone(new Runnable() {
+                            @Override
+                            public void run() {
+                                inspections.selectInspectionGroup(new String[]{inspectionGroupPath});
+                            }
+                        });
+                    }
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/command/MicroprofileUpdateConfigurationAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/command/MicroprofileUpdateConfigurationAction.java
@@ -25,7 +25,7 @@ import com.intellij.profile.codeInspection.InspectionProfileManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.impl.FakePsiElement;
 import com.redhat.devtools.intellij.lsp4ij.commands.CommandExecutor;
-import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections.AbstractDelegateInspectionWithExcludedProperties;
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspectionWithExclusions;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections.MicroProfilePropertiesUnassignedInspection;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections.MicroProfilePropertiesUnknownInspection;
 import org.eclipse.lsp4j.Command;
@@ -43,7 +43,6 @@ public class MicroprofileUpdateConfigurationAction extends AnAction {
     private final Map<String, ConfigurationUpdater> updaters = new HashMap<>();
 
     public MicroprofileUpdateConfigurationAction() {
-        //TODO potentially load those from an extension point?
         updaters.put("microprofile.tools.validation.unknown.excluded", new InspectionConfigurationUpdater(MicroProfilePropertiesUnknownInspection.ID));
         updaters.put("microprofile.tools.validation.unassigned.excluded", new InspectionConfigurationUpdater(MicroProfilePropertiesUnassignedInspection.ID));
     }
@@ -99,8 +98,8 @@ public class MicroprofileUpdateConfigurationAction extends AnAction {
         private void updateConfiguration(Project project,  @NotNull String value) {
             InspectionProfile profile = InspectionProfileManager.getInstance(project).getCurrentProfile();
             InspectionToolWrapper<?, ?> toolWrapper = profile.getInspectionTool(inspectionId, project);
-            if (toolWrapper != null && toolWrapper.getTool() instanceof AbstractDelegateInspectionWithExcludedProperties) {
-                Key<AbstractDelegateInspectionWithExcludedProperties> key = new Key<>(inspectionId);
+            if (toolWrapper != null && toolWrapper.getTool() instanceof AbstractDelegateInspectionWithExclusions) {
+                Key<AbstractDelegateInspectionWithExclusions> key = new Key<>(inspectionId);
                 profile.modifyToolSettings(key, getPsiElement(project), (tool) -> {
                     tool.excludeList.add(value);
                 });

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesDuplicatesInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesDuplicatesInspection.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
 
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspection;
+
 /**
  * Dummy inspection for duplicate properties in Microprofile properties files
  */

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesExpressionsInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesExpressionsInspection.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
 
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspection;
+
 /**
  * Dummy inspection for expression values in Microprofile properties files
  */

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesGlobalInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesGlobalInspection.java
@@ -11,12 +11,13 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-package com.redhat.devtools.intellij.qute.psi.core.inspections;
+package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
 
-import com.intellij.codeInspection.LocalInspectionTool;
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspection;
 
 /**
- * No-op {@link LocalInspectionTool} used as a basis for mapping inspection severities to matching LSP severities.
+ * Dummy inspection for general validation in Microprofile properties files
  */
-public abstract class AbstractDelegateInspection extends LocalInspectionTool {
+public class MicroProfilePropertiesGlobalInspection extends AbstractDelegateInspection {
+    public static final String ID = getShortName(MicroProfilePropertiesGlobalInspection.class.getSimpleName());
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesRequiredInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesRequiredInspection.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
 
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspection;
+
 /**
  * Dummy inspection for missing required properties in Microprofile properties files
  */

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesUnassignedInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesUnassignedInspection.java
@@ -13,9 +13,17 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
 
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspectionWithExclusions;
+import com.redhat.devtools.intellij.lsp4mp4ij.MicroProfileBundle;
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Dummy inspection for unknown properties in Microprofile properties files
  */
-public class MicroProfilePropertiesUnassignedInspection extends AbstractDelegateInspectionWithExcludedProperties {
+public class MicroProfilePropertiesUnassignedInspection extends AbstractDelegateInspectionWithExclusions {
     public static final String ID = getShortName(MicroProfilePropertiesUnassignedInspection.class.getSimpleName());
+
+    public MicroProfilePropertiesUnassignedInspection() {
+        super(MicroProfileBundle.message("microprofile.properties.validation.excluded.properties"));
+    }
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesUnknownInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesUnknownInspection.java
@@ -13,16 +13,19 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
 
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspectionWithExclusions;
+import com.redhat.devtools.intellij.lsp4mp4ij.MicroProfileBundle;
+
 import java.util.Arrays;
 
 /**
  * Dummy inspection for unknown properties in Microprofile properties files
  */
-public class MicroProfilePropertiesUnknownInspection extends AbstractDelegateInspectionWithExcludedProperties {
+public class MicroProfilePropertiesUnknownInspection extends AbstractDelegateInspectionWithExclusions {
     public static final String ID = getShortName(MicroProfilePropertiesUnknownInspection.class.getSimpleName());
 
     public MicroProfilePropertiesUnknownInspection() {
-        super();
+        super(MicroProfileBundle.message("microprofile.properties.validation.excluded.properties"));
         excludeList.addAll(Arrays.asList("*/mp-rest/providers/*/priority", "mp.openapi.schema.*", "kafka-streams.*", "camel.*"));
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesValueInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/inspections/MicroProfilePropertiesValueInspection.java
@@ -13,9 +13,11 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
 
+import com.intellij.codeInspection.LocalInspectionTool;
+
 /**
  * Dummy inspection for invalid values in Microprofile properties files
  */
-public class MicroProfilePropertiesValueInspection extends AbstractDelegateInspection {
+public class MicroProfilePropertiesValueInspection extends LocalInspectionTool {
     public static final String ID = getShortName(MicroProfilePropertiesValueInspection.class.getSimpleName());
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/settings/MicroProfileConfigurable.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/settings/MicroProfileConfigurable.java
@@ -62,24 +62,11 @@ public class MicroProfileConfigurable extends NamedConfigurable<UserDefinedMicro
 
 
     @Override
-    public void reset() {
-        if (myView == null) return;
-        UserDefinedMicroProfileSettings settings = UserDefinedMicroProfileSettings.getInstance(project);
-        myView.setValidationEnabled(settings.isValidationEnabled());
-    }
-
-    @Override
     public boolean isModified() {
-        if (myView == null) return false;
-        UserDefinedMicroProfileSettings settings = UserDefinedMicroProfileSettings.getInstance(project);
-        return !(myView.isValidationEnabled()== settings.isValidationEnabled());
+        return false;
     }
 
     @Override
     public void apply() throws ConfigurationException {
-        if (myView == null) return;
-        UserDefinedMicroProfileSettings settings = UserDefinedMicroProfileSettings.getInstance(project);
-        settings.setValidationEnabled(myView.isValidationEnabled());
-        settings.fireStateChanged();
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/settings/MicroProfileInspectionsInfo.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/settings/MicroProfileInspectionsInfo.java
@@ -17,6 +17,7 @@ import com.intellij.codeInspection.InspectionProfile;
 import com.intellij.codeInspection.ex.InspectionToolWrapper;
 import com.intellij.openapi.project.Project;
 import com.intellij.profile.codeInspection.InspectionProfileManager;
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspectionWithExclusions;
 import com.redhat.devtools.intellij.lsp4ij.operations.diagnostics.SeverityMapping;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections.*;
 import org.eclipse.lsp4j.DiagnosticSeverity;
@@ -42,12 +43,15 @@ public class MicroProfileInspectionsInfo {
     private List<String> excludedUnknownProperties;
     private List<String> excludedUnassignedProperties;
 
+    private boolean enabled = true;
+
     private MicroProfileInspectionsInfo() {
     }
 
     public static MicroProfileInspectionsInfo getMicroProfileInspectionInfo(Project project) {
         MicroProfileInspectionsInfo wrapper = new MicroProfileInspectionsInfo();
         InspectionProfile profile = InspectionProfileManager.getInstance(project).getCurrentProfile();
+        wrapper.enabled = SeverityMapping.getSeverity(MicroProfilePropertiesGlobalInspection.ID, profile) != null;
         wrapper.syntaxSeverity = SeverityMapping.getSeverity(MicroProfilePropertiesSyntaxInspection.ID, profile);
         wrapper.unknownSeverity = SeverityMapping.getSeverity(MicroProfilePropertiesUnknownInspection.ID, profile);
         wrapper.duplicateSeverity = SeverityMapping.getSeverity(MicroProfilePropertiesDuplicatesInspection.ID, profile);
@@ -65,11 +69,15 @@ public class MicroProfileInspectionsInfo {
     private static List<String> getExclusions(InspectionProfile profile, String inspectionId, Project project) {
         List<String> exclusions = new ArrayList<>();
         InspectionToolWrapper<?, ?> toolWrapper = profile.getInspectionTool(inspectionId, project);
-        if (toolWrapper != null && toolWrapper.getTool() instanceof AbstractDelegateInspectionWithExcludedProperties) {
-            AbstractDelegateInspectionWithExcludedProperties inspection = (AbstractDelegateInspectionWithExcludedProperties) toolWrapper.getTool();
+        if (toolWrapper != null && toolWrapper.getTool() instanceof AbstractDelegateInspectionWithExclusions) {
+            AbstractDelegateInspectionWithExclusions inspection = (AbstractDelegateInspectionWithExclusions) toolWrapper.getTool();
             exclusions.addAll(inspection.excludeList);
         }
         return exclusions;
+    }
+
+    public boolean enabled() {
+        return enabled;
     }
 
     public DiagnosticSeverity unknownSeverity() {
@@ -113,11 +121,12 @@ public class MicroProfileInspectionsInfo {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         MicroProfileInspectionsInfo that = (MicroProfileInspectionsInfo) o;
-        return syntaxSeverity == that.syntaxSeverity && unknownSeverity == that.unknownSeverity && duplicateSeverity == that.duplicateSeverity && valueSeverity == that.valueSeverity && requiredSeverity == that.requiredSeverity && expressionSeverity == that.expressionSeverity && unassignedSeverity == that.unassignedSeverity && Objects.equals(excludedUnknownProperties, that.excludedUnknownProperties) && Objects.equals(excludedUnassignedProperties, that.excludedUnassignedProperties);
+        return enabled == that.enabled && syntaxSeverity == that.syntaxSeverity && unknownSeverity == that.unknownSeverity && duplicateSeverity == that.duplicateSeverity && valueSeverity == that.valueSeverity && requiredSeverity == that.requiredSeverity && expressionSeverity == that.expressionSeverity && unassignedSeverity == that.unassignedSeverity && Objects.equals(excludedUnknownProperties, that.excludedUnknownProperties) && Objects.equals(excludedUnassignedProperties, that.excludedUnassignedProperties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(syntaxSeverity, unknownSeverity, duplicateSeverity, valueSeverity, requiredSeverity, expressionSeverity, unassignedSeverity, excludedUnknownProperties, excludedUnassignedProperties);
+        return Objects.hash(enabled, syntaxSeverity, unknownSeverity, duplicateSeverity, valueSeverity, requiredSeverity, expressionSeverity, unassignedSeverity, excludedUnknownProperties, excludedUnassignedProperties);
     }
+
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/settings/MicroProfileView.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/settings/MicroProfileView.java
@@ -14,16 +14,12 @@
 package com.redhat.devtools.intellij.lsp4mp4ij.settings;
 
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.options.ConfigurationException;
-import com.intellij.ui.IdeBorderFactory;
-import com.intellij.ui.components.JBCheckBox;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
-import com.intellij.util.ui.UI;
+import com.redhat.devtools.intellij.lsp4ij.ui.components.InspectionHyperlink;
 import com.redhat.devtools.intellij.lsp4mp4ij.MicroProfileBundle;
 
 import javax.swing.*;
-import javax.swing.border.TitledBorder;
 
 /**
  * MicroProfile view.
@@ -31,8 +27,6 @@ import javax.swing.border.TitledBorder;
 public class MicroProfileView implements Disposable {
 
     private final JPanel myMainPanel;
-
-    private JBCheckBox validationEnabledCheckBox = new JBCheckBox(MicroProfileBundle.message("microprofile.validation.enabled"));
 
     public MicroProfileView() {
         JPanel settingsPanel = createSettings();
@@ -43,7 +37,7 @@ public class MicroProfileView implements Disposable {
 
     private JPanel createSettings() {
         return FormBuilder.createFormBuilder()
-                .addComponent(validationEnabledCheckBox)
+                .addComponent(new InspectionHyperlink(MicroProfileBundle.message("microprofile.inspection.link"), "MicroProfile"))
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
     }
@@ -56,13 +50,4 @@ public class MicroProfileView implements Disposable {
     public void dispose() {
 
     }
-
-    public boolean isValidationEnabled() {
-        return validationEnabledCheckBox.isSelected();
-    }
-
-    public void setValidationEnabled(boolean enable) {
-        validationEnabledCheckBox.setSelected(enable);
-    }
-
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/settings/UserDefinedMicroProfileSettings.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/settings/UserDefinedMicroProfileSettings.java
@@ -140,7 +140,7 @@ public class UserDefinedMicroProfileSettings implements PersistentStateComponent
 
         Map<String, Object> validation = new HashMap<>();
         tools.put("validation", validation);
-        validation.put("enabled", isValidationEnabled());
+        validation.put("enabled", inspectionsInfo.enabled());
         validation.put("syntax", getSeverityNode(inspectionsInfo.syntaxSeverity()));
         validation.put("duplicate", getSeverityNode(inspectionsInfo.duplicateSeverity()));
         validation.put("value", getSeverityNode(inspectionsInfo.valueSeverity()));

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusLanguageClient.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusLanguageClient.java
@@ -89,7 +89,7 @@ public class QuarkusLanguageClient extends IndexAwareLanguageClient implements M
 
     @Override
     public void profileChanged(@NotNull InspectionProfile profile) {
-        // Track MicroProfile inspections settings (declared in Editor/Inspection/MicroProfue UI settings) changed,
+        // Track MicroProfile inspections settings (declared in Editor/Inspection/MicroProfile UI settings) changed,
         // convert them to matching LSP4MP configuration and push them via 'workspace/didChangeConfiguration'.
         MicroProfileInspectionsInfo newInspectionState = MicroProfileInspectionsInfo.getMicroProfileInspectionInfo(getProject());
         if (!Objects.equals(newInspectionState, inspectionsInfo)) {

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteLanguageSubstitutor.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteLanguageSubstitutor.java
@@ -34,7 +34,8 @@ import org.jetbrains.annotations.Nullable;
  */
 public class QuteLanguageSubstitutor extends LanguageSubstitutor {
     protected boolean isTemplate(VirtualFile file, Module module) {
-        return file.getPath().contains("templates") && ModuleRootManager.getInstance(module).getFileIndex().isInSourceContent(file);
+        return file.getPath().contains("templates") &&
+                ModuleRootManager.getInstance(module).getFileIndex().isInSourceContent(file);
     }
 
     protected boolean isQuteModule(Module module) {
@@ -42,7 +43,7 @@ public class QuteLanguageSubstitutor extends LanguageSubstitutor {
         return libraries.process(new RootPolicy<Boolean>() {
             @Override
             public Boolean visitLibraryOrderEntry(@NotNull LibraryOrderEntry libraryOrderEntry, Boolean value) {
-                return value | isQuteLibrary(libraryOrderEntry);
+                return value || isQuteLibrary(libraryOrderEntry);
             }
         }, false);
 

--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteServer.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteServer.java
@@ -56,7 +56,7 @@ public class QuteServer extends ProcessStreamConnectionProvider {
         Map<String, Object> extendedClientCapabilities = new HashMap<>();
         Map<String, Object> commands = new HashMap<>();
         Map<String, Object> commandsKind = new HashMap<>();
-        commandsKind.put("valueSet", Arrays.asList("qute.command.java.definition", /* TODO support "qute.command.configuration.update" , */ "qute.command.open.uri"));
+        commandsKind.put("valueSet", Arrays.asList("qute.command.java.definition", "qute.command.configuration.update" , "qute.command.open.uri"));
         commands.put("commandsKind", commandsKind);
         extendedClientCapabilities.put("commands", commands);
         extendedClientCapabilities.put("shouldLanguageServerExitOnShutdown", Boolean.TRUE);

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/core/command/QuteUpdateConfigurationAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/core/command/QuteUpdateConfigurationAction.java
@@ -1,0 +1,204 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.intellij.qute.psi.core.command;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.intellij.codeHighlighting.HighlightDisplayLevel;
+import com.intellij.codeInsight.daemon.HighlightDisplayKey;
+import com.intellij.codeInspection.InspectionProfile;
+import com.intellij.codeInspection.ex.InspectionProfileImpl;
+import com.intellij.codeInspection.ex.InspectionToolWrapper;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.profile.codeInspection.InspectionProfileManager;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.FakePsiElement;
+import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.intellij.lsp4ij.commands.CommandExecutor;
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspectionWithExclusions;
+import com.redhat.devtools.intellij.lsp4ij.operations.diagnostics.SeverityMapping;
+import com.redhat.devtools.intellij.qute.psi.core.inspections.QuteGlobalInspection;
+import com.redhat.devtools.intellij.qute.psi.core.inspections.QuteUndefinedObjectInspection;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class QuteUpdateConfigurationAction extends AnAction {
+    private final Map<String, ConfigurationUpdater> updaters = new HashMap<>();
+
+    public QuteUpdateConfigurationAction() {
+        updaters.put("qute.validation.enabled", new InspectionEnabler(QuteGlobalInspection.ID));
+        updaters.put("qute.validation.excluded", new InspectionExclusionsUpdater(QuteGlobalInspection.ID));
+        updaters.put("qute.validation.undefinedObject.severity",  new InspectionSeverityUpdater(QuteUndefinedObjectInspection.ID));
+    }
+
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent e) {
+        JsonObject configUpdate = getConfigUpdate(e);
+        if (configUpdate != null && e.getProject() != null) {
+            String section = configUpdate.get("section").getAsString();
+            ConfigurationUpdater updater = updaters.get(section);
+            if (updater == null) {
+                throw new UnsupportedOperationException("Updating '" + section + "' is not supported yet!");
+            }
+            updater.updateConfiguration(e.getProject(), configUpdate);
+        }
+    }
+
+    private @Nullable JsonObject getConfigUpdate(@NotNull AnActionEvent e) {
+        @Nullable Command command = e.getData(CommandExecutor.LSP_COMMAND);
+        if (command == null) {
+            return null;
+        }
+        List<Object> arguments = command.getArguments();
+        if (arguments != null && !arguments.isEmpty()) {
+            Object arg = arguments.get(0);
+            if (arg instanceof JsonObject) {
+                return (JsonObject) arg;
+            }
+        }
+        return null;
+    }
+
+    interface ConfigurationUpdater {
+        void updateConfiguration(Project project,  JsonObject value);
+    }
+
+    private static class InspectionSeverityUpdater implements ConfigurationUpdater {
+        protected final String inspectionId;
+
+        InspectionSeverityUpdater(String inspectionId) {
+            this.inspectionId = inspectionId;
+        }
+
+        @Override
+        public void updateConfiguration(Project project, JsonObject configUpdate) {
+            JsonElement value = configUpdate.get("value");
+            if (value == null) {
+                return;
+            }
+            String severity = value.getAsString();
+            if ("ignore".equals(severity)) {
+                disableInspection(project);
+            } else {
+                setSeverity(project, DiagnosticSeverity.valueOf(severity));
+            }
+        }
+
+        private void disableInspection(Project project) {
+            InspectionProfileImpl profile = InspectionProfileManager.getInstance(project).getCurrentProfile();
+            profile.setToolEnabled(inspectionId, false, project);
+        }
+
+        private void setSeverity(Project project, DiagnosticSeverity severity) {
+            InspectionProfileImpl profile = InspectionProfileManager.getInstance(project).getCurrentProfile();
+            HighlightDisplayLevel level = HighlightDisplayLevel.find(SeverityMapping.toHighlightSeverity(severity));
+            profile.setErrorLevel(HighlightDisplayKey.find(inspectionId), level, project);
+        }
+    }
+
+    private static class InspectionExclusionsUpdater extends InspectionSeverityUpdater {
+
+        InspectionExclusionsUpdater(String inspectionId) {
+            super(inspectionId) ;
+        }
+
+        @Override
+        public void updateConfiguration(Project project, JsonObject configUpdate) {
+            JsonElement value = configUpdate.get("value");
+            if (value != null) {
+                addToExclusions(project, value.getAsString());
+            }
+        }
+
+        protected void addToExclusions(Project project, @NotNull String value) {
+            InspectionProfile profile = InspectionProfileManager.getInstance(project).getCurrentProfile();
+            InspectionToolWrapper<?, ?> toolWrapper = profile.getInspectionTool(inspectionId, project);
+            if (toolWrapper != null && toolWrapper.getTool() instanceof AbstractDelegateInspectionWithExclusions) {
+                Key<AbstractDelegateInspectionWithExclusions> key = new Key<>(inspectionId);
+                profile.modifyToolSettings(key, getPsiElement(project), (tool) -> {
+                    tool.excludeList.add(sanitize(project, value));
+                });
+            }
+        }
+
+        /**
+         * returns file value path relative to the given project
+         * @param project the reference project
+         * @param value the file path URI to get a relative path from
+         * @return file value path relative to the given project
+         */
+        private String sanitize(@NotNull Project project, @NotNull String value) {
+            if (value.startsWith("file:/")) {
+                try {
+                    URI projectURI = LSPIJUtils.toUri(project);
+                    URI fileURI = new URI(value);
+                    return projectURI.relativize(fileURI).toString();
+                } catch (URISyntaxException ignore) {
+                }
+            }
+            return value;
+        }
+
+        private PsiElement getPsiElement(Project project) {
+            return new FakePsiElement() {
+                @Override
+                public PsiElement getParent() {
+                    return null;
+                }
+
+                @Override
+                public @NotNull Project getProject() {
+                    return project;
+                }
+            };
+        }
+    }
+
+    /**
+     * Simulates a module-wide validation disabling by adding <module-path>/** to exclusions
+     */
+    private static class InspectionEnabler extends InspectionExclusionsUpdater {
+
+        InspectionEnabler(String inspectionId) {
+            super(inspectionId);
+        }
+
+        @Override
+        public void updateConfiguration(Project project, JsonObject value) {
+            String scopeUri = value.get("scopeUri").getAsString();
+            VirtualFile resource = LSPIJUtils.findResourceFor(scopeUri);
+            if (resource != null) {
+                @Nullable Module module = LSPIJUtils.getModule(resource);
+                if (module != null) {
+                    String modulePath = LSPIJUtils.toUri(module).resolve("**").toString();
+                    addToExclusions(project, modulePath);
+                }
+            }
+        }
+
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/core/inspections/QuteGlobalInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/core/inspections/QuteGlobalInspection.java
@@ -11,12 +11,18 @@
  * Contributors:
  *     Red Hat Inc. - initial API and implementation
  *******************************************************************************/
-package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections;
+package com.redhat.devtools.intellij.qute.psi.core.inspections;
 
-import com.intellij.codeInspection.LocalInspectionTool;
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspectionWithExclusions;
+import com.redhat.devtools.intellij.qute.QuteBundle;
 
 /**
- * No-op {@link LocalInspectionTool} used as a basis for mapping inspection severities to matching LSP severities.
+ * Dummy inspection for general validation in Qute template files
  */
-public abstract class AbstractDelegateInspection extends LocalInspectionTool {
+public class QuteGlobalInspection extends AbstractDelegateInspectionWithExclusions {
+    public static final String ID = getShortName(QuteGlobalInspection.class.getSimpleName());
+
+    QuteGlobalInspection() {
+        super(QuteBundle.message("qute.validation.excluded.options.label"));
+    }
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/core/inspections/QuteUndefinedNamespaceInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/core/inspections/QuteUndefinedNamespaceInspection.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.qute.psi.core.inspections;
 
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspection;
+
 /**
  * Dummy inspection for undefined namespaces in Qute templates
  */

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/core/inspections/QuteUndefinedObjectInspection.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/core/inspections/QuteUndefinedObjectInspection.java
@@ -13,6 +13,8 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.qute.psi.core.inspections;
 
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspection;
+
 /**
  * Dummy inspection for undefined objects in Qute templates
  */

--- a/src/main/java/com/redhat/devtools/intellij/qute/settings/QuteConfigurable.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/settings/QuteConfigurable.java
@@ -65,7 +65,6 @@ public class QuteConfigurable extends NamedConfigurable<UserDefinedQuteSettings>
     public void reset() {
         if (myView == null) return;
         UserDefinedQuteSettings settings = UserDefinedQuteSettings.getInstance(project);
-        myView.setValidationEnabled(settings.isValidationEnabled());
         myView.setNativeModeSupportEnabled(settings.isNativeModeSupportEnabled());
     }
 
@@ -73,15 +72,13 @@ public class QuteConfigurable extends NamedConfigurable<UserDefinedQuteSettings>
     public boolean isModified() {
         if (myView == null) return false;
         UserDefinedQuteSettings settings = UserDefinedQuteSettings.getInstance(project);
-        return myView.isValidationEnabled() != settings.isValidationEnabled() ||
-                myView.isNativeModeSupportEnabled() != settings.isNativeModeSupportEnabled();
+        return myView.isNativeModeSupportEnabled() != settings.isNativeModeSupportEnabled();
     }
 
     @Override
     public void apply() throws ConfigurationException {
         if (myView == null) return;
         UserDefinedQuteSettings settings = UserDefinedQuteSettings.getInstance(project);
-        settings.setValidationEnabled(myView.isValidationEnabled());
         settings.setNativeModeSupportEnabled(myView.isNativeModeSupportEnabled());
         settings.fireStateChanged();
     }

--- a/src/main/java/com/redhat/devtools/intellij/qute/settings/QuteInspectionsInfo.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/settings/QuteInspectionsInfo.java
@@ -13,18 +13,20 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.qute.settings;
 
-import com.intellij.codeHighlighting.HighlightDisplayLevel;
-import com.intellij.codeInsight.daemon.HighlightDisplayKey;
 import com.intellij.codeInspection.InspectionProfile;
-import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.codeInspection.ex.InspectionToolWrapper;
 import com.intellij.openapi.project.Project;
 import com.intellij.profile.codeInspection.InspectionProfileManager;
 import com.redhat.devtools.intellij.lsp4ij.operations.diagnostics.SeverityMapping;
+import com.redhat.devtools.intellij.lsp4ij.inspections.AbstractDelegateInspectionWithExclusions;
+import com.redhat.devtools.intellij.qute.psi.core.inspections.QuteGlobalInspection;
 import com.redhat.devtools.intellij.qute.psi.core.inspections.QuteUndefinedNamespaceInspection;
 import com.redhat.devtools.intellij.qute.psi.core.inspections.QuteUndefinedObjectInspection;
 import org.eclipse.lsp4j.DiagnosticSeverity;
-import org.gradle.configurationcache.problems.ProblemSeverity;
-import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Contains Qute inspection settings relevant to Qute LS configuration
@@ -32,8 +34,16 @@ import org.jetbrains.annotations.NotNull;
 //TODO switch to a record, when Java 17 is required
 public class QuteInspectionsInfo {
 
+    private boolean enabled = true;
     private DiagnosticSeverity undefinedObjectSeverity = DiagnosticSeverity.Warning;
     private DiagnosticSeverity undefinedNamespaceSeverity = DiagnosticSeverity.Warning;
+
+    public List<String> getExcludedFiles() {
+        return excludedFiles;
+    }
+
+    private List<String> excludedFiles;
+
 
     private QuteInspectionsInfo() {
     }
@@ -41,8 +51,10 @@ public class QuteInspectionsInfo {
     public static QuteInspectionsInfo getQuteInspectionsInfo(Project project) {
         QuteInspectionsInfo wrapper = new QuteInspectionsInfo();
         InspectionProfile profile = InspectionProfileManager.getInstance(project).getCurrentProfile();
+        wrapper.enabled = SeverityMapping.getSeverity(QuteGlobalInspection.ID, profile) != null;
         wrapper.undefinedObjectSeverity = SeverityMapping.getSeverity(QuteUndefinedObjectInspection.ID, profile);
         wrapper.undefinedNamespaceSeverity = SeverityMapping.getSeverity(QuteUndefinedNamespaceInspection.ID, profile);
+        wrapper.excludedFiles = getExclusions(profile, QuteGlobalInspection.ID, project);
         return wrapper;
     }
 
@@ -54,4 +66,30 @@ public class QuteInspectionsInfo {
         return undefinedNamespaceSeverity;
     }
 
+    public boolean enabled() {
+        return enabled;
+    }
+
+    private static List<String> getExclusions(InspectionProfile profile, String inspectionId, Project project) {
+        List<String> exclusions = new ArrayList<>();
+        InspectionToolWrapper<?, ?> toolWrapper = profile.getInspectionTool(inspectionId, project);
+        if (toolWrapper != null && toolWrapper.getTool() instanceof AbstractDelegateInspectionWithExclusions) {
+            AbstractDelegateInspectionWithExclusions inspection = (AbstractDelegateInspectionWithExclusions) toolWrapper.getTool();
+            exclusions.addAll(inspection.excludeList);
+        }
+        return exclusions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        QuteInspectionsInfo that = (QuteInspectionsInfo) o;
+        return enabled == that.enabled && undefinedObjectSeverity == that.undefinedObjectSeverity && undefinedNamespaceSeverity == that.undefinedNamespaceSeverity && Objects.equals(excludedFiles, that.excludedFiles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, undefinedObjectSeverity, undefinedNamespaceSeverity, excludedFiles);
+    }
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/settings/QuteView.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/settings/QuteView.java
@@ -18,6 +18,7 @@ import com.intellij.ui.components.JBCheckBox;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UI;
+import com.redhat.devtools.intellij.lsp4ij.ui.components.InspectionHyperlink;
 import com.redhat.devtools.intellij.qute.QuteBundle;
 
 import javax.swing.*;
@@ -29,7 +30,6 @@ public class QuteView implements Disposable {
 
     private final JPanel myMainPanel;
 
-    private JBCheckBox validationEnabledCheckBox = new JBCheckBox(QuteBundle.message("qute.setting.validation.enabled"));
     private JBCheckBox nativeModeSupportEnabledCheckBox = new JBCheckBox(QuteBundle.message("qute.setting.validation.native.enabled"));
 
     public QuteView() {
@@ -39,7 +39,7 @@ public class QuteView implements Disposable {
 
     private JPanel createSettings() {
         return FormBuilder.createFormBuilder()
-                .addComponent(validationEnabledCheckBox)
+                .addComponent(new InspectionHyperlink(QuteBundle.message("qute.inspection.link"), "Qute"))
                 .addComponent(nativeModeSupportEnabledCheckBox)
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
@@ -52,14 +52,6 @@ public class QuteView implements Disposable {
     @Override
     public void dispose() {
 
-    }
-
-    public boolean isValidationEnabled() {
-        return validationEnabledCheckBox.isSelected();
-    }
-
-    public void setValidationEnabled(boolean enabled) {
-        validationEnabledCheckBox.setSelected(enabled);
     }
 
     public boolean isNativeModeSupportEnabled() {

--- a/src/main/java/com/redhat/devtools/intellij/qute/settings/UserDefinedQuteSettings.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/settings/UserDefinedQuteSettings.java
@@ -152,7 +152,10 @@ public class UserDefinedQuteSettings implements PersistentStateComponent<UserDef
         // Validation
         Map<String, Object> validation = new HashMap<>();
         qute.put("validation", validation);
-        validation.put("enabled", isValidationEnabled());
+
+        validation.put("enabled", inspectionsInfo.enabled());
+        validation.put("excluded", inspectionsInfo.getExcludedFiles());
+
         validation.put("undefinedObject", getSeverityNode(inspectionsInfo.undefinedObjectSeverity()));
         validation.put("undefinedNamespace", getSeverityNode(inspectionsInfo.undefinedNamespaceSeverity()));
         return settings;

--- a/src/main/resources/META-INF/lsp4ij-quarkus.xml
+++ b/src/main/resources/META-INF/lsp4ij-quarkus.xml
@@ -1,5 +1,4 @@
 <idea-plugin>
-
   <extensions defaultExtensionNs="com.redhat.devtools.intellij.quarkus">
     <!-- Quarkus LSP -->
     <server id="quarkus"
@@ -61,6 +60,15 @@
     <codeInsight.inlayProvider language="Properties"
                                implementationClass="com.redhat.devtools.intellij.lsp4ij.operations.inlayhint.LSPInlayHintInlayProvider"/>
 
+
+    <localInspection
+            language="Properties"
+            bundle="messages.MicroProfileBundle"
+            key="microprofile.properties.validation"
+            groupKey="microprofile.inspection.group.name"
+            enabledByDefault="true"
+            level="INFORMATION"
+            implementationClass="com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections.MicroProfilePropertiesGlobalInspection"/>
     <localInspection
             language="Properties"
             bundle="messages.MicroProfileBundle"

--- a/src/main/resources/META-INF/lsp4ij-qute.xml
+++ b/src/main/resources/META-INF/lsp4ij-qute.xml
@@ -53,6 +53,17 @@
                          bundle="messages.QuteBundle"
                          key="qute.settings.title"
                          instance="com.redhat.devtools.intellij.qute.settings.QuteConfigurable"/>
+
+    <localInspection
+            unfair="true"
+            language="Qute_"
+            bundle="messages.QuteBundle"
+            key="qute.templates.inspection"
+            groupKey="qute.inspection.group.name"
+            enabledByDefault="true"
+            level="INFORMATION"
+            implementationClass="com.redhat.devtools.intellij.qute.psi.core.inspections.QuteGlobalInspection"/>
+
     <localInspection
             unfair="true"
             language="Qute_"
@@ -61,7 +72,6 @@
             groupPathKey="qute.inspection.group.name"
             groupKey="qute.templates.inspection.group.name"
             enabledByDefault="true"
-
             level="WARNING"
             implementationClass="com.redhat.devtools.intellij.qute.psi.core.inspections.QuteUndefinedObjectInspection"/>
     <localInspection

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -571,6 +571,8 @@
             class="com.redhat.devtools.intellij.qute.psi.core.command.QuteGenerateTemplateAction"/>
     <action id="qute.command.java.definition"
             class="com.redhat.devtools.intellij.qute.psi.core.command.QuteJavaDefinitionAction"/>
+    <action id="qute.command.configuration.update"
+            class="com.redhat.devtools.intellij.qute.psi.core.command.QuteUpdateConfigurationAction"/>
 
   </actions>
 </idea-plugin>

--- a/src/main/resources/inspectionDescriptions/MicroProfilePropertiesGlobal.html
+++ b/src/main/resources/inspectionDescriptions/MicroProfilePropertiesGlobal.html
@@ -1,0 +1,17 @@
+<html>
+<body>
+Enables global validation for MicroProfile
+<p>
+</p>
+<div style="border-left: 6px solid #e7af18; display: block; padding:5px">
+    <p style="margin:5px">
+        &#9888; This inspection is used to configure the <b>Tools for MicroProfile</b> server in <a href="settings://LanguageServers"> Settings | Languages &amp; Frameworks | Language Servers</a>.<br/><br/>
+        Consequently, some limitations apply:
+    </p>
+    <ul>
+        <li><i>Scope</i>, <i>Severity</i>, <i>Highlighting in Editor</i> values are ignored</li>
+        <li>Disabling this inspection will disable all MicroProfile inspections, regardless of their state</li>
+    </ul>
+</div>
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/QuteGlobal.html
+++ b/src/main/resources/inspectionDescriptions/QuteGlobal.html
@@ -1,0 +1,17 @@
+<html>
+<body>
+Enables global validation for Qute
+<p>
+</p>
+<div style="border-left: 6px solid #e7af18; display: block; padding:5px">
+    <p style="margin:5px">
+        &#9888; This inspection is used to configure the <b>Qute support</b> server in <a href="settings://LanguageServers"> Settings | Languages &amp; Frameworks | Language Servers</a>.<br/><br/>
+        Consequently, some limitations apply:
+    </p>
+    <ul>
+        <li><i>Scope</i>, <i>Severity</i>, <i>Highlighting in Editor</i> values are ignored</li>
+        <li>Disabling this inspection will disable all Qute inspections, regardless of their state</li>
+    </ul>
+</div>
+</body>
+</html>

--- a/src/main/resources/messages/MicroProfileBundle.properties
+++ b/src/main/resources/messages/MicroProfileBundle.properties
@@ -19,12 +19,13 @@ microprofile.properties.inspection.group.name=Properties
 microprofile.java.inspection.group.name=Java files
 microprofile.inspection.group.name=MicroProfile
 
-microprofile.validation.enabled=Enable validation
+microprofile.inspection.link=Configure Microprofile inspections
 
 ## MicroProfile UI settings page for properties files
 microprofile.properties=Properties
 microprofile.properties.title=MicroProfile configuration in microprofile-config.properties
 microprofile.properties.inlayHint.enabled=Show evaluated property expression as inlay hint?
+microprofile.properties.validation=Validation
 microprofile.properties.validation.syntax=Syntax checking
 microprofile.properties.validation.unknown=Unknown properties
 microprofile.properties.validation.duplicate=Duplicate properties

--- a/src/main/resources/messages/QuteBundle.properties
+++ b/src/main/resources/messages/QuteBundle.properties
@@ -25,8 +25,10 @@ qute.settings.title=Qute
 
 
 qute.inspection.group.name=Qute
+qute.inspection.link=Configure Qute inspections
+qute.templates.inspection=Validation
 qute.templates.inspection.group.name=Templates
 qute.templates.validation.undefinedNamespace=Undefined namespaces
 qute.templates.validation.undefinedObject=Undefined objects
-qute.setting.validation.enabled=Enable validation
 qute.setting.validation.native.enabled=Enable native image mode support
+qute.validation.excluded.options.label=Files excluded from the Qute validation


### PR DESCRIPTION
<img width="1834" alt="Screenshot 2023-09-11 at 12 11 32" src="https://github.com/redhat-developer/intellij-quarkus/assets/148698/388f9112-2c32-4d17-83c2-9e053554ed02">

The "enable validation" buttons where moved from the MicroProfile / Qute settings sections into a MicroProfile / Validation and Qute / Validation inspections instead