### PR TITLE
fix: use HH:mm:ss format for message timestamps in LSP view

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/TracingMessageConsumer.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/explorer/TracingMessageConsumer.java
@@ -47,7 +47,7 @@ public class TracingMessageConsumer {
         this.sentRequests = new ConcurrentHashMap<>();
         this.receivedRequests = new ConcurrentHashMap<>();
         this.clock = Clock.systemDefaultZone();
-        this.dateTimeFormatter = DateTimeFormatter.ofPattern("KK:mm:ss a").withZone(clock.getZone());
+        this.dateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss").withZone(clock.getZone());
     }
 
     /**


### PR DESCRIPTION

<img width="1267" alt="Screenshot 2023-09-27 at 14 00 14" src="https://github.com/redhat-developer/intellij-quarkus/assets/148698/8e90512e-5a9e-487b-b884-7d4c31b17bbd">


Fixes #1182

