### PR TITLE
fix: Quarkus completion is available in all *.properties files in a Quarkus project

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/microprofile/lang/MicroProfileFileType.java
+++ b/src/main/java/com/redhat/devtools/intellij/microprofile/lang/MicroProfileFileType.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.microprofile.lang;
+
+import com.intellij.openapi.fileTypes.LanguageFileType;
+import com.intellij.openapi.util.IconLoader;
+import com.redhat.devtools.intellij.quarkus.lang.QuarkusIconProvider;
+import com.redhat.devtools.intellij.qute.lang.QuteLanguage;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import javax.swing.*;
+
+/**
+ * MicroProfile language file type.
+ */
+public class MicroProfileFileType extends LanguageFileType {
+    private static final Icon QUARKUS_ICON = IconLoader.findIcon("/quarkus_icon_rgb_16px_default.png", QuarkusIconProvider.class);
+
+    @NotNull
+    public static final MicroProfileFileType INSTANCE = new MicroProfileFileType();
+
+    private MicroProfileFileType() {
+        super(MicroProfileLanguage.INSTANCE);
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return "MicroProfile";
+    }
+
+    @Override
+    public @NotNull
+    String getDescription() {
+        return "MicroProfile";
+    }
+
+    @Override
+    public @NotNull String getDefaultExtension() {
+        return "properties";
+    }
+
+    @Override
+    public @Nullable Icon getIcon() {
+        return QUARKUS_ICON;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/microprofile/lang/MicroProfileLanguage.java
+++ b/src/main/java/com/redhat/devtools/intellij/microprofile/lang/MicroProfileLanguage.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.microprofile.lang;
+
+import com.intellij.lang.InjectableLanguage;
+import com.intellij.lang.Language;
+import com.intellij.openapi.util.NlsSafe;
+import com.intellij.psi.templateLanguages.TemplateLanguage;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Qute language.
+ */
+public class MicroProfileLanguage extends Language {
+
+    @NotNull
+    public static final MicroProfileLanguage INSTANCE = new MicroProfileLanguage();
+
+    private MicroProfileLanguage() {
+        super("MicroProfile");
+    }
+
+    @Override
+    public @NotNull
+    @NlsSafe String getDisplayName() {
+        return "MicroProfile";
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/microprofile/lang/MicroProfileLanguageSubstitutor.java
+++ b/src/main/java/com/redhat/devtools/intellij/microprofile/lang/MicroProfileLanguageSubstitutor.java
@@ -1,0 +1,20 @@
+package com.redhat.devtools.intellij.microprofile.lang;
+
+import com.intellij.lang.Language;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.LanguageSubstitutor;
+import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class MicroProfileLanguageSubstitutor extends LanguageSubstitutor {
+
+    @Override
+    public @Nullable Language getLanguage(@NotNull VirtualFile file, @NotNull Project project) {
+        if (QuarkusModuleUtil.isQuarkusPropertiesFile(file, project) || QuarkusModuleUtil.isQuarkusYAMLFile(file, project)) {
+            return MicroProfileLanguage.INSTANCE;
+        }
+        return null;
+    }
+}

--- a/src/main/resources/META-INF/lsp4ij-quarkus.xml
+++ b/src/main/resources/META-INF/lsp4ij-quarkus.xml
@@ -17,7 +17,7 @@
         ]]>
       </description>
     </server>
-    <languageMapping language="Properties" serverId="quarkus"/>
+    <languageMapping language="MicroProfile" serverId="quarkus"/>
     <languageMapping language="JAVA" serverId="quarkus"/>
     <serverIconProvider serverId="quarkus" class="com.redhat.devtools.intellij.microprofile.lang.MicroProfileServerIconProvider" />
   </extensions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -328,6 +328,13 @@
             order="before javaClassReference"
             implementationClass="com.redhat.devtools.intellij.quarkus.lang.QuarkusPropertyClassNameCompletionRemover"/>
 
+    <!-- MicroProfile -->
+    <lang.substitutor language="Properties" implementationClass="com.redhat.devtools.intellij.microprofile.lang.MicroProfileLanguageSubstitutor"/>
+    <fileType name="MicroProfile"
+              language="MicroProfile"
+              instance="INSTANCE"
+              implementationClass="com.redhat.devtools.intellij.microprofile.lang.MicroProfileFileType"/>
+
     <properties.implicitPropertyUsageProvider implementation="com.redhat.devtools.intellij.quarkus.lang.QuarkusImplicitPropertyUsageProvider"/>
     <projectService serviceImplementation="com.redhat.devtools.intellij.quarkus.QuarkusProjectService"/>
     <projectService serviceImplementation="com.redhat.devtools.intellij.lsp4mp4ij.classpath.ClasspathResourceChangedManager"/>


### PR DESCRIPTION
fix: Quarkus completion is available in all *.properties files in a Quarkus project

Fixes #1121