### PR TITLE
feat: Check if project is a MicroProfile, Qute, etc project to map file with a language server

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/ContentTypeToLanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/ContentTypeToLanguageServerDefinition.java
@@ -1,17 +1,27 @@
 package com.redhat.devtools.intellij.lsp4ij;
 
 import com.intellij.lang.Language;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
 
 import javax.annotation.Nonnull;
 import java.util.AbstractMap;
 
 public class ContentTypeToLanguageServerDefinition extends AbstractMap.SimpleEntry<Language, LanguageServersRegistry.LanguageServerDefinition> {
+
+    private final DocumentMatcher documentMatcher;
     public ContentTypeToLanguageServerDefinition(@Nonnull Language language,
-                                                 @Nonnull LanguageServersRegistry.LanguageServerDefinition provider) {
+                                                 DocumentMatcher documentMatcher, @Nonnull LanguageServersRegistry.LanguageServerDefinition provider) {
         super(language, provider);
+        this.documentMatcher = documentMatcher;
     }
 
     public boolean isEnabled() {
         return true;
+    }
+
+    public boolean matches(Document document, VirtualFile file, Project project) {
+        return documentMatcher.match(document, file, project);
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/DefaultDocumentMatcher.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/DefaultDocumentMatcher.java
@@ -1,0 +1,21 @@
+package com.redhat.devtools.intellij.lsp4ij;
+
+import com.intellij.lang.Language;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
+
+public class DefaultDocumentMatcher implements DocumentMatcher{
+
+    public static final DocumentMatcher INSTANCE = new DefaultDocumentMatcher();
+
+    @Override
+    public boolean match(Document document, VirtualFile file, Project fileProject) {
+       return true;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/DocumentMatcher.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/DocumentMatcher.java
@@ -1,0 +1,10 @@
+package com.redhat.devtools.intellij.lsp4ij;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+
+public interface DocumentMatcher {
+
+    boolean match(Document document, VirtualFile file, Project fileProject);
+}

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/LanguageMappingExtensionPointBean.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/LanguageMappingExtensionPointBean.java
@@ -2,9 +2,12 @@ package com.redhat.devtools.intellij.lsp4ij;
 
 import com.intellij.openapi.extensions.AbstractExtensionPointBean;
 import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.project.Project;
+import com.intellij.serviceContainer.BaseKeyedLazyInstance;
 import com.intellij.util.xmlb.annotations.Attribute;
+import org.jetbrains.annotations.Nullable;
 
-public class LanguageMappingExtensionPointBean extends AbstractExtensionPointBean {
+public class LanguageMappingExtensionPointBean extends BaseKeyedLazyInstance<DocumentMatcher> {
     public static final ExtensionPointName<LanguageMappingExtensionPointBean> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.languageMapping");
 
     @Attribute("id")
@@ -15,4 +18,21 @@ public class LanguageMappingExtensionPointBean extends AbstractExtensionPointBea
 
     @Attribute("serverId")
     public String serverId;
+
+    @Attribute("documentMatcher")
+    public String documentMatcher;
+
+    public DocumentMatcher getDocumentMatcher() {
+        try {
+            return super.getInstance();
+        }
+        catch(Exception e) {
+            return DefaultDocumentMatcher.INSTANCE;
+        }
+    }
+
+    @Override
+    protected @Nullable String getImplementationClassName() {
+        return documentMatcher;
+    }
 }

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/AbstractQuarkusDocumentMatcher.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/AbstractQuarkusDocumentMatcher.java
@@ -1,0 +1,18 @@
+package com.redhat.devtools.intellij.quarkus.lsp;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.lsp4ij.DocumentMatcher;
+import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
+import com.redhat.devtools.intellij.qute.psi.utils.PsiQuteProjectUtils;
+
+public class AbstractQuarkusDocumentMatcher implements DocumentMatcher {
+    @Override
+    public boolean match(Document document, VirtualFile file, Project fileProject) {
+        Module module = LSPIJUtils.getModule(file);
+        return module != null &&  QuarkusModuleUtil.isQuarkusModule(module);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusDocumentMatcherForJavaFile.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusDocumentMatcherForJavaFile.java
@@ -1,0 +1,12 @@
+package com.redhat.devtools.intellij.quarkus.lsp;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
+
+public class QuarkusDocumentMatcherForJavaFile extends AbstractQuarkusDocumentMatcher {
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusDocumentMatcherForPropertiesFile.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusDocumentMatcherForPropertiesFile.java
@@ -1,0 +1,21 @@
+package com.redhat.devtools.intellij.quarkus.lsp;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
+
+public class QuarkusDocumentMatcherForPropertiesFile extends AbstractQuarkusDocumentMatcher {
+
+    @Override
+    public boolean match(Document document, VirtualFile file, Project fileProject) {
+        if (!matchFile(file, fileProject)) {
+            return false;
+        }
+        return super.match(document, file, fileProject);
+    }
+
+    private boolean matchFile(VirtualFile file, Project fileProject) {
+        return QuarkusModuleUtil.isQuarkusPropertiesFile(file, fileProject) ||  QuarkusModuleUtil.isQuarkusYAMLFile(file, fileProject);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteLanguageSubstitutor.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteLanguageSubstitutor.java
@@ -25,6 +25,8 @@ import com.intellij.psi.LanguageSubstitutor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static com.redhat.devtools.intellij.qute.psi.utils.PsiQuteProjectUtils.isQuteTemplate;
+
 /**
  * Qute language substitutor to force some language file (ex:HTML, YAML, etc) to "_Qute" language when:
  * <ul>
@@ -33,10 +35,6 @@ import org.jetbrains.annotations.Nullable;
  * </ul>
  */
 public class QuteLanguageSubstitutor extends LanguageSubstitutor {
-    protected boolean isTemplate(VirtualFile file, Module module) {
-        return file.getPath().contains("templates") &&
-                ModuleRootManager.getInstance(module).getFileIndex().isInSourceContent(file);
-    }
 
     protected boolean isQuteModule(Module module) {
         OrderEnumerator libraries = ModuleRootManager.getInstance(module).orderEntries().librariesOnly();
@@ -70,7 +68,7 @@ public class QuteLanguageSubstitutor extends LanguageSubstitutor {
     public @Nullable Language getLanguage(@NotNull VirtualFile file, @NotNull Project project) {
         Module module = ModuleUtilCore.findModuleForFile(file, project);
         if (module != null) {
-            if (isTemplate(file, module) && isQuteModule(module)) {
+            if (isQuteTemplate(file, module) && isQuteModule(module)) {
                 return QuteLanguage.INSTANCE;
             }
         }

--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/AbstractQuteDocumentMatcher.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/AbstractQuteDocumentMatcher.java
@@ -1,0 +1,18 @@
+package com.redhat.devtools.intellij.qute.lsp;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.lsp4ij.DocumentMatcher;
+import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.intellij.qute.psi.utils.PsiQuteProjectUtils;
+
+public class AbstractQuteDocumentMatcher implements DocumentMatcher {
+
+    @Override
+    public boolean match(Document document, VirtualFile file, Project fileProject) {
+        Module module = LSPIJUtils.getModule(file);
+        return module != null &&  PsiQuteProjectUtils.hasQuteSupport(module);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuarkusPropertiesDocumentMatcher.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuarkusPropertiesDocumentMatcher.java
@@ -1,0 +1,21 @@
+package com.redhat.devtools.intellij.qute.lsp;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
+
+public class QuarkusPropertiesDocumentMatcher extends QuteDocumentMatcherForJavaFile {
+
+    @Override
+    public boolean match(Document document, VirtualFile file, Project fileProject) {
+        if (!matchFile(file, fileProject)) {
+            return false;
+        }
+        return super.match(document, file, fileProject);
+    }
+
+    private boolean matchFile(VirtualFile file, Project fileProject) {
+        return QuarkusModuleUtil.isQuarkusPropertiesFile(file, fileProject) ||  QuarkusModuleUtil.isQuarkusYAMLFile(file, fileProject);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteDocumentMatcherForJavaFile.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteDocumentMatcherForJavaFile.java
@@ -1,0 +1,12 @@
+package com.redhat.devtools.intellij.qute.lsp;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.lsp4ij.DocumentMatcher;
+import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
+
+public class QuteDocumentMatcherForJavaFile extends AbstractQuteDocumentMatcher {
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteDocumentMatcherForTemplateFile.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteDocumentMatcherForTemplateFile.java
@@ -1,0 +1,20 @@
+package com.redhat.devtools.intellij.qute.lsp;
+
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.intellij.qute.psi.utils.PsiQuteProjectUtils;
+
+import static com.redhat.devtools.intellij.qute.psi.utils.PsiQuteProjectUtils.isQuteTemplate;
+
+public class QuteDocumentMatcherForTemplateFile extends AbstractQuteDocumentMatcher {
+
+    @Override
+    public boolean match(Document document, VirtualFile file, Project fileProject) {
+        if (!super.match(document, file, fileProject)) {
+            return false;
+        }
+        return isQuteTemplate(file, LSPIJUtils.getModule(file));
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/utils/PsiQuteProjectUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/utils/PsiQuteProjectUtils.java
@@ -14,6 +14,8 @@ package com.redhat.devtools.intellij.qute.psi.utils;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
 import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.intellij.qute.psi.internal.QuteJavaConstants;
@@ -120,5 +122,10 @@ public class PsiQuteProjectUtils {
 		if (!segment.endsWith("/")) {
 			path.append('/');
 		}
+	}
+
+	public static boolean isQuteTemplate(VirtualFile file, Module module) {
+		return file.getPath().contains("templates") &&
+				ModuleRootManager.getInstance(module).getFileIndex().isInSourceContent(file);
 	}
 }

--- a/src/main/resources/META-INF/lsp4ij-quarkus.xml
+++ b/src/main/resources/META-INF/lsp4ij-quarkus.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.redhat.devtools.intellij.quarkus">
     <!-- Quarkus LSP -->
-    <server id="quarkus"
+    <server id="microprofile"
             label="Tools for MicroProfile"
             class="com.redhat.devtools.intellij.quarkus.lsp.QuarkusServer"
             clientImpl="com.redhat.devtools.intellij.quarkus.lsp.QuarkusLanguageClient"
@@ -17,9 +17,13 @@
         ]]>
       </description>
     </server>
-    <languageMapping language="Properties" serverId="quarkus"/>
-    <languageMapping language="JAVA" serverId="quarkus"/>
-    <serverIconProvider serverId="quarkus" class="com.redhat.devtools.intellij.microprofile.lang.MicroProfileServerIconProvider" />
+    <languageMapping language="Properties"
+                     serverId="microprofile"
+                     documentMatcher="com.redhat.devtools.intellij.quarkus.lsp.QuarkusDocumentMatcherForPropertiesFile" />
+    <languageMapping language="JAVA"
+                     serverId="microprofile"
+                     documentMatcher="com.redhat.devtools.intellij.quarkus.lsp.QuarkusDocumentMatcherForJavaFile"/>
+    <serverIconProvider serverId="microprofile" class="com.redhat.devtools.intellij.microprofile.lang.MicroProfileServerIconProvider" />
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/src/main/resources/META-INF/lsp4ij-qute.xml
+++ b/src/main/resources/META-INF/lsp4ij-qute.xml
@@ -17,8 +17,12 @@
         ]]>
       </description>
     </server>
-    <languageMapping language="Qute_" serverId="qute"/>
-    <languageMapping language="JAVA" serverId="qute"/>
+    <languageMapping language="Qute_"
+                     serverId="qute"
+                     documentMatcher="com.redhat.devtools.intellij.qute.lsp.QuteDocumentMatcherForTemplateFile"/>
+    <languageMapping language="JAVA"
+                     serverId="qute"
+                     documentMatcher="com.redhat.devtools.intellij.qute.lsp.QuteDocumentMatcherForJavaFile"/>
     <serverIconProvider serverId="qute" class="com.redhat.devtools.intellij.quarkus.lang.QuarkusServerIconProvider" />
   </extensions>
 


### PR DESCRIPTION
feat: Check if project is a MicroProfile, Qute, etc project to map file with a language server

Fixes #850
Fixes #1121

This PR provides a new API `DocumentMatcher` which is used to match the document with a language server. This matcher is called if the file language is mapped with a language server. Once language is matched, teh document filter is processed to have more robust filter:

 * for properties file, we check the  name of properties files which fixes #1121
 * for Java file, we check that the file belong to a Quarkus / Qute project. It means that if you have a java project which is not a Qute / Quarkus project, language server should never started
 * for HTML files, we check that html files belongs to templates folder and belong to a Qute project.

The `DocumentMatcher` is used for the moment only when file is opened,it means if we add / remove a Qute / Quarkus dependency, it will change nothing. You will need to close all files and reoping it. @fbricon perhaps we could see that in an another PR?