### PR TITLE
feat: Check if project is a MicroProfile, Qute, etc project to map file with a language server

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/AbstractDocumentMatcher.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/AbstractDocumentMatcher.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.lsp4ij;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.lsp4ij.internal.PromiseToCompletableFuture;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Abstract document matcher which prevent the execute of the match in an read action and when IJ is not indexing.
+ */
+public abstract class AbstractDocumentMatcher implements DocumentMatcher {
+
+    private class CompletableFutureWrapper extends PromiseToCompletableFuture<Boolean> {
+
+        public CompletableFutureWrapper(@NotNull VirtualFile file, @NotNull Project project) {
+            super(indicator -> {
+                        return AbstractDocumentMatcher.this.match(file, project);
+                    }, "Match with " + AbstractDocumentMatcher.this.getClass().getName(),
+                    project, null, AbstractDocumentMatcher.class, file.getUrl());
+            init();
+        }
+    }
+
+    @Override
+    public @NotNull CompletableFuture<Boolean> matchAsync(@NotNull VirtualFile file, @NotNull Project project) {
+        return new CompletableFutureWrapper(file, project);
+    }
+
+    @Override
+    public boolean shouldBeMatchedAsynchronously(@NotNull Project project) {
+        if (ApplicationManager.getApplication().isUnitTestMode()) {
+            return false;
+        }
+        if (!ApplicationManager.getApplication().isReadAccessAllowed()) {
+            return true;
+        }
+        return DumbService.getInstance(project).isDumb();
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/ContentTypeToLanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/ContentTypeToLanguageServerDefinition.java
@@ -1,17 +1,37 @@
 package com.redhat.devtools.intellij.lsp4ij;
 
 import com.intellij.lang.Language;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
 
-import javax.annotation.Nonnull;
 import java.util.AbstractMap;
+import java.util.concurrent.CompletableFuture;
 
 public class ContentTypeToLanguageServerDefinition extends AbstractMap.SimpleEntry<Language, LanguageServersRegistry.LanguageServerDefinition> {
-    public ContentTypeToLanguageServerDefinition(@Nonnull Language language,
-                                                 @Nonnull LanguageServersRegistry.LanguageServerDefinition provider) {
+
+    private final DocumentMatcher documentMatcher;
+
+    public ContentTypeToLanguageServerDefinition(@NotNull Language language,
+                                                 @NotNull LanguageServersRegistry.LanguageServerDefinition provider,
+                                                 @NotNull DocumentMatcher documentMatcher) {
         super(language, provider);
+        this.documentMatcher = documentMatcher;
+    }
+
+    public boolean match(VirtualFile file, Project project) {
+        return documentMatcher.match(file, project);
+    }
+
+    public boolean shouldBeMatchedAsynchronously(Project project) {
+        return documentMatcher.shouldBeMatchedAsynchronously(project);
     }
 
     public boolean isEnabled() {
-        return true;
+        return getValue().isEnabled();
+    }
+
+    public @NotNull <R> CompletableFuture<Boolean> matchAsync(VirtualFile file, Project project) {
+        return documentMatcher.matchAsync(file, project);
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/DocumentMatcher.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/DocumentMatcher.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.lsp4ij;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.concurrency.CancellablePromise;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * When a file is opened, the LSP support connect all available language server which matches the language of the file.
+ * <p>
+ * DocumentMatcher provides the capability to add advanced filter like check the file name, check that project have some Java classes in the classpath.
+ */
+public interface DocumentMatcher {
+
+    /**
+     * Returns true if the given file matches a mapping with a language server and false otherwise.
+     *
+     * @param file    teh file to check.
+     * @param project the file project.
+     * @return true if the given file matches a mapping with a language server and false otherwise.
+     */
+    boolean match(@NotNull VirtualFile file, @NotNull Project project);
+
+    /**
+     * Returns true if the given file matches a mapping with a language server and false otherwise.
+     * <p>
+     * In this case,the match is done in async mode. A typical usecase is when the matcher need to check that a given Java class belongs to the project or the file belongs to a source folder.
+     * To evaluate this match, the read action mode is required and it can create a non blocking read action to evaluate the match.
+     *
+     * @param file
+     * @param project
+     * @return true if the given file matches a mapping with a language server and false otherwise.
+     * @see AbstractDocumentMatcher
+     */
+    default @NotNull CompletableFuture<Boolean> matchAsync(@NotNull VirtualFile file, @NotNull Project project) {
+        return CompletableFuture.completedFuture(match(file, project));
+    }
+
+    /**
+     * Returns true if the match must be done asynchronously and false otherwise.
+     * <p>
+     * A typical usecase is when IJ is indexing or read action is not allowed,this method should return true, to execute match in a non blocking read action.
+     *
+     * @param project the project.
+     * @return true if the match must be done asynchronously and false otherwise.
+     * @see AbstractDocumentMatcher
+     */
+    default boolean shouldBeMatchedAsynchronously(@NotNull Project project) {
+        return false;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/LanguageMappingExtensionPointBean.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/LanguageMappingExtensionPointBean.java
@@ -2,9 +2,15 @@ package com.redhat.devtools.intellij.lsp4ij;
 
 import com.intellij.openapi.extensions.AbstractExtensionPointBean;
 import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.serviceContainer.BaseKeyedLazyInstance;
 import com.intellij.util.xmlb.annotations.Attribute;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public class LanguageMappingExtensionPointBean extends AbstractExtensionPointBean {
+public class LanguageMappingExtensionPointBean extends BaseKeyedLazyInstance<DocumentMatcher> {
+
+    private static final DocumentMatcher DEFAULT_DOCUMENT_MATCHER = (file,project) -> true;
+
     public static final ExtensionPointName<LanguageMappingExtensionPointBean> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.languageMapping");
 
     @Attribute("id")
@@ -15,4 +21,21 @@ public class LanguageMappingExtensionPointBean extends AbstractExtensionPointBea
 
     @Attribute("serverId")
     public String serverId;
+
+    @Attribute("documentMatcher")
+    public String documentMatcher;
+
+    public @NotNull DocumentMatcher getDocumentMatcher() {
+        try {
+            return super.getInstance();
+        }
+        catch(Exception e) {
+            return DEFAULT_DOCUMENT_MATCHER;
+        }
+    }
+
+    @Override
+    protected @Nullable String getImplementationClassName() {
+        return documentMatcher;
+    }
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/client/LSPCompletableFuture.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/client/LSPCompletableFuture.java
@@ -13,148 +13,26 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4ij.client;
 
-import com.intellij.openapi.application.ReadAction;
-import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.project.DumbService;
-import com.intellij.openapi.project.IndexNotReadyException;
-import com.intellij.util.concurrency.AppExecutorUtil;
-import com.redhat.devtools.intellij.lsp4ij.LanguageServersRegistry;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.concurrency.CancellablePromise;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.redhat.devtools.intellij.lsp4ij.internal.PromiseToCompletableFuture;
 
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 /**
  * LSP completable future which execute a given function code in a non blocking reading action promise.
  */
-public class LSPCompletableFuture<R> extends CompletableFuture<R> {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(LSPCompletableFuture.class);
-
-    private class ResultOrError<R> {
-
-        public final R result;
-
-        public final Exception error;
-
-        public ResultOrError(R result, Exception error) {
-            this.result = result;
-            this.error = error;
-        }
-    }
-
-    private static final int MAX_ATTEMPT = 5;
-    private final Function<ProgressIndicator, R> code;
+public class LSPCompletableFuture<R> extends PromiseToCompletableFuture<R> {
     private final IndexAwareLanguageClient languageClient;
-    private final String progressTitle;
-    private final AtomicInteger nbAttempt;
-
-    private final Object coalesceBy;
-    private CancellablePromise<ResultOrError<R>> nonBlockingReadActionPromise;
 
     public LSPCompletableFuture(Function<ProgressIndicator, R> code, String progressTitle, IndexAwareLanguageClient languageClient, Object coalesceBy) {
-        this.code = code;
-        this.progressTitle = progressTitle;
+        super(code, progressTitle, languageClient.getProject(), languageClient, coalesceBy);
         this.languageClient = languageClient;
-        this.coalesceBy = coalesceBy;
-        this.nbAttempt = new AtomicInteger(0);
-        // if indexation is processing, we need to execute the promise in smart mode
-        var executeInSmartMode = DumbService.getInstance(languageClient.getProject()).isDumb();
-        var promise = nonBlockingReadActionPromise(executeInSmartMode);
-        bind(promise);
-    }
-
-    /**
-     * Bind the given promise with the completable future.
-     *
-     * @param promise the promise which will execute the function code in a non blocking read action context
-     */
-    private void bind(CancellablePromise<ResultOrError<R>> promise) {
-        this.nonBlockingReadActionPromise = promise;
-        // On error...
-        promise.onError(ex -> {
-            if (ex instanceof ProcessCanceledException || ex instanceof CancellationException) {
-                // Case 2: cancel the completable future
-                this.cancel(true);
-            } else {
-                // Other case..., mark the completable future as error
-                this.completeExceptionally(ex);
-            }
-        });
-        // On success...
-        promise.onSuccess(value -> {
-            if (value.error != null) {
-                Exception ex = value.error;
-                // There were an error with IndexNotReadyException or ReadAction.CannotReadException
-                // Case 1: Attempt to retry the start of the promise
-                if (nbAttempt.incrementAndGet() >= MAX_ATTEMPT) {
-                    // 1.1 Maximum number reached, mark the completable future as error
-                    LOGGER.warn("Maximum number (" + MAX_ATTEMPT + ")" + " of attempts to start non blocking read action for '" + progressTitle + "' has been reached", ex);
-                    this.completeExceptionally(new ExecutionAttemptLimitReachedException(progressTitle, MAX_ATTEMPT, ex));
-                } else {
-                    // Retry ...
-                    // 1.2 Index are not ready or the read action cannot be done, retry in smart mode...
-                    LOGGER.warn("Restart non blocking read action for '" + progressTitle + "' with attempt " + nbAttempt.get() + "/" + MAX_ATTEMPT + ".", ex);
-                    var newPromise = nonBlockingReadActionPromise(true);
-                    bind(newPromise);
-                }
-            } else {
-                this.complete(value.result);
-            }
-        });
-    }
-
-    /**
-     * Create a non blocking read action promise.
-     *
-     * @param executeInSmartMode true if the promise must be executed in smart mode and false otherwise.
-     * @return a non blocking read action promise
-     */
-    @NotNull
-    private CancellablePromise<ResultOrError<R>> nonBlockingReadActionPromise(boolean executeInSmartMode) {
-        var project = languageClient.getProject();
-
-        var indicator = new LSPProgressIndicator(languageClient);
-        indicator.setText(progressTitle);
-        var action = ReadAction.nonBlocking(() ->
-                {
-                    try {
-                        R result = code.apply(indicator);
-                        return new ResultOrError<R>(result, null);
-                    } catch (IndexNotReadyException | ReadAction.CannotReadException e) {
-                        // When there is any exception, AsyncPromise report a log error.
-                        // As we retry to execute the function code 5 times, we don't want to log this error
-                        // To do that we catch the error and recreate a new promise on the promise.onSuccess
-                        return new ResultOrError<R>(null, e);
-                    }
-                })
-                .wrapProgress(indicator)
-                .expireWith(languageClient); // promise is canceled when language client is stopped
-        if (executeInSmartMode) {
-            action = action.inSmartMode(project);
-        }
-        if (coalesceBy != null) {
-            action = action.coalesceBy(coalesceBy);
-        }
-        return action
-                .submit(AppExecutorUtil.getAppExecutorService());
+        init();
     }
 
     @Override
-    public boolean cancel(boolean mayInterruptIfRunning) {
-        if (nonBlockingReadActionPromise != null) {
-            // cancel the current promise
-            if (!nonBlockingReadActionPromise.isDone()) {
-                nonBlockingReadActionPromise.cancel(mayInterruptIfRunning);
-            }
-        }
-        return super.cancel(mayInterruptIfRunning);
+    protected ProgressIndicator createProgressIndicator() {
+        return new LSPProgressIndicator(languageClient);
     }
 
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/internal/PromiseToCompletableFuture.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/internal/PromiseToCompletableFuture.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.lsp4ij.internal;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.progress.EmptyProgressIndicator;
+import com.intellij.openapi.progress.ProcessCanceledException;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.IndexNotReadyException;
+import com.intellij.openapi.project.Project;
+import com.intellij.util.concurrency.AppExecutorUtil;
+import com.redhat.devtools.intellij.lsp4ij.client.ExecutionAttemptLimitReachedException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.concurrency.CancellablePromise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+/**
+ * LSP completable future which execute a given function code in a non blocking reading action promise.
+ */
+public class PromiseToCompletableFuture<R> extends CompletableFuture<R> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PromiseToCompletableFuture.class);
+
+    private class ResultOrError<R> {
+
+        public final R result;
+
+        public final Exception error;
+
+        public ResultOrError(R result, Exception error) {
+            this.result = result;
+            this.error = error;
+        }
+    }
+
+    private static final int MAX_ATTEMPT = 5;
+
+    private final Function<ProgressIndicator,R> code;
+
+    private final String progressTitle;
+
+    private final Project project;
+    private final Disposable parentDisposable;
+
+    private final AtomicInteger nbAttempt;
+
+    private final Object[] coalesceBy;
+    private CancellablePromise<ResultOrError<R>> nonBlockingReadActionPromise;
+
+    public PromiseToCompletableFuture(@NotNull Function<ProgressIndicator, R> code, @NotNull String progressTitle, @NotNull Project project, @Nullable Disposable parentDisposable, Object... coalesceBy) {
+        this.code = code;
+        this.progressTitle = progressTitle;
+        this.project = project;
+        this.parentDisposable = parentDisposable;
+        this.coalesceBy = coalesceBy;
+        this.nbAttempt = new AtomicInteger(0);
+    }
+
+    protected void init() {
+        // if indexation is processing, we need to execute the promise in smart mode
+        var executeInSmartMode = DumbService.getInstance(project).isDumb();
+        var promise = nonBlockingReadActionPromise(executeInSmartMode);
+        bind(promise);
+    }
+
+    /**
+     * Bind the given promise with the completable future.
+     *
+     * @param promise the promise which will execute the function code in a non blocking read action context
+     */
+    private void bind(CancellablePromise<ResultOrError<R>> promise) {
+        this.nonBlockingReadActionPromise = promise;
+        // On error...
+        promise.onError(ex -> {
+            if (ex instanceof ProcessCanceledException || ex instanceof CancellationException) {
+                // Case 2: cancel the completable future
+                this.cancel(true);
+            } else {
+                // Other case..., mark the completable future as error
+                this.completeExceptionally(ex);
+            }
+        });
+        // On success...
+        promise.onSuccess(value -> {
+            if (value.error != null) {
+                Exception ex = value.error;
+                // There were an error with IndexNotReadyException or ReadAction.CannotReadException
+                // Case 1: Attempt to retry the start of the promise
+                if (nbAttempt.incrementAndGet() >= MAX_ATTEMPT) {
+                    // 1.1 Maximum number reached, mark the completable future as error
+                    LOGGER.warn("Maximum number (" + MAX_ATTEMPT + ")" + " of attempts to start non blocking read action for '" + progressTitle + "' has been reached", ex);
+                    this.completeExceptionally(new ExecutionAttemptLimitReachedException(progressTitle, MAX_ATTEMPT, ex));
+                } else {
+                    // Retry ...
+                    // 1.2 Index are not ready or the read action cannot be done, retry in smart mode...
+                    LOGGER.warn("Restart non blocking read action for '" + progressTitle + "' with attempt " + nbAttempt.get() + "/" + MAX_ATTEMPT + ".", ex);
+                    var newPromise = nonBlockingReadActionPromise(true);
+                    bind(newPromise);
+                }
+            } else {
+                this.complete(value.result);
+            }
+        });
+    }
+
+    /**
+     * Create a non blocking read action promise.
+     *
+     * @param executeInSmartMode true if the promise must be executed in smart mode and false otherwise.
+     * @return a non blocking read action promise
+     */
+    @NotNull
+    private CancellablePromise<ResultOrError<R>> nonBlockingReadActionPromise(boolean executeInSmartMode) {
+        var indicator = createProgressIndicator();
+        indicator.setText(progressTitle);
+        var action = ReadAction.nonBlocking(() ->
+                {
+                    try {
+                        R result = code.apply(indicator);
+                        return new ResultOrError<R>(result, null);
+                    } catch (IndexNotReadyException | ReadAction.CannotReadException e) {
+                        // When there is any exception, AsyncPromise report a log error.
+                        // As we retry to execute the function code 5 times, we don't want to log this error
+                        // To do that we catch the error and recreate a new promise on the promise.onSuccess
+                        return new ResultOrError<R>(null, e);
+                    }
+                })
+                .wrapProgress(indicator);
+        if (parentDisposable != null) {
+            action = action.expireWith(parentDisposable); // ex: promise is canceled when language client is stopped
+        }
+        if (executeInSmartMode) {
+            action = action.inSmartMode(project);
+        }
+        if (coalesceBy != null) {
+            action = action.coalesceBy(coalesceBy);
+        }
+        return action
+                .submit(AppExecutorUtil.getAppExecutorService());
+    }
+
+    protected ProgressIndicator createProgressIndicator() {
+        return new EmptyProgressIndicator();
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        if (nonBlockingReadActionPromise != null) {
+            // cancel the current promise
+            if (!nonBlockingReadActionPromise.isDone()) {
+                nonBlockingReadActionPromise.cancel(mayInterruptIfRunning);
+            }
+        }
+        return super.cancel(mayInterruptIfRunning);
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/QuarkusModuleUtil.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/QuarkusModuleUtil.java
@@ -228,18 +228,21 @@ public class QuarkusModuleUtil {
     public static boolean isQuarkusPropertiesFile(VirtualFile file, Project project) {
         if (APPLICATION_PROPERTIES.matcher(file.getName()).matches() ||
                 MICROPROFILE_CONFIG_PROPERTIES.matcher(file.getName()).matches()) {
-            Module module = ModuleUtilCore.findModuleForFile(file, project);
-            return module != null && FacetManager.getInstance(module).getFacetByType(QuarkusFacet.FACET_TYPE_ID) != null;
+            return isQuarkusModule(file, project);
         }
         return false;
     }
 
     public static boolean isQuarkusYAMLFile(VirtualFile file, Project project) {
         if (APPLICATION_YAML.matcher(file.getName()).matches()) {
-            Module module = ModuleUtilCore.findModuleForFile(file, project);
-            return module != null && FacetManager.getInstance(module).getFacetByType(QuarkusFacet.FACET_TYPE_ID) != null;
+            return isQuarkusModule(file, project);
         }
         return false;
+    }
+
+    private static boolean isQuarkusModule(VirtualFile file, Project project) {
+        Module module = ModuleUtilCore.findModuleForFile(file, project);
+        return module != null && (FacetManager.getInstance(module).getFacetByType(QuarkusFacet.FACET_TYPE_ID) != null || QuarkusModuleUtil.isQuarkusModule(module));
     }
 
     public static VirtualFile getModuleDirPath(Module module) {

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/AbstractQuarkusDocumentMatcher.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/AbstractQuarkusDocumentMatcher.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.quarkus.lsp;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.lsp4ij.AbstractDocumentMatcher;
+import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
+
+/**
+ * Base class for Quarkus document matcher which checks that the file belongs to a Quarkus project.
+ */
+public class AbstractQuarkusDocumentMatcher extends AbstractDocumentMatcher {
+
+    @Override
+    public boolean match(VirtualFile file, Project fileProject) {
+        Module module = LSPIJUtils.getModule(file);
+        return module != null && QuarkusModuleUtil.isQuarkusModule(module);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusDocumentMatcherForJavaFile.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusDocumentMatcherForJavaFile.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.quarkus.lsp;
+
+/**
+ * Quarkus document matcher for Java file which checks that a Java file belongs to a Quarkus project.
+ */
+public class QuarkusDocumentMatcherForJavaFile extends AbstractQuarkusDocumentMatcher {
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusDocumentMatcherForPropertiesFile.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusDocumentMatcherForPropertiesFile.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.quarkus.lsp;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
+
+/**
+ * Quarkus document matcher for application.properties, microprofile-config.properties
+ * file which checks that the properties file belongs to a Quarkus project.
+ */
+public class QuarkusDocumentMatcherForPropertiesFile extends AbstractQuarkusDocumentMatcher {
+
+    @Override
+    public boolean match(VirtualFile file, Project fileProject) {
+        if (!matchFile(file, fileProject)) {
+            return false;
+        }
+        return super.match(file, fileProject);
+    }
+
+    private boolean matchFile(VirtualFile file, Project fileProject) {
+        return QuarkusModuleUtil.isQuarkusPropertiesFile(file, fileProject) || QuarkusModuleUtil.isQuarkusYAMLFile(file, fileProject);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteLanguageSubstitutor.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteLanguageSubstitutor.java
@@ -25,6 +25,8 @@ import com.intellij.psi.LanguageSubstitutor;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import static com.redhat.devtools.intellij.qute.psi.utils.PsiQuteProjectUtils.isQuteTemplate;
+
 /**
  * Qute language substitutor to force some language file (ex:HTML, YAML, etc) to "_Qute" language when:
  * <ul>
@@ -34,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public class QuteLanguageSubstitutor extends LanguageSubstitutor {
     protected boolean isTemplate(VirtualFile file, Module module) {
-        return file.getPath().contains("templates") &&
+        return isQuteTemplate(file, module) &&
                 ModuleRootManager.getInstance(module).getFileIndex().isInSourceContent(file);
     }
 

--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/AbstractQuteDocumentMatcher.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/AbstractQuteDocumentMatcher.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.qute.lsp;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.lsp4ij.AbstractDocumentMatcher;
+import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.intellij.qute.psi.utils.PsiQuteProjectUtils;
+
+/**
+ * Base class for Qute document matcher which checks that the file belongs to a Qute project.
+ */
+public class AbstractQuteDocumentMatcher extends AbstractDocumentMatcher {
+
+    @Override
+    public boolean match(VirtualFile file, Project fileProject) {
+        Module module = LSPIJUtils.getModule(file);
+        return module != null && PsiQuteProjectUtils.hasQuteSupport(module);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteDocumentMatcherForJavaFile.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteDocumentMatcherForJavaFile.java
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.qute.lsp;
+
+/**
+ * Qute document matcher for Java file which checks that a Java file belongs to a Qute project.
+ */
+public class QuteDocumentMatcherForJavaFile extends AbstractQuteDocumentMatcher {
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteDocumentMatcherForTemplateFile.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteDocumentMatcherForTemplateFile.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.qute.lsp;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
+
+import static com.redhat.devtools.intellij.qute.psi.utils.PsiQuteProjectUtils.isQuteTemplate;
+
+/**
+ * Qute document matcher for html, yaml, txt, json files which checks that the file belongs to a Qute project and it is hosted in the template folder (ex : src/main/resources/templates)
+ */
+public class QuteDocumentMatcherForTemplateFile extends AbstractQuteDocumentMatcher {
+
+    @Override
+    public boolean match(VirtualFile file, Project fileProject) {
+        if (!super.match(file, fileProject)) {
+            return false;
+        }
+        return isQuteTemplate(file, LSPIJUtils.getModule(file));
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/utils/PsiQuteProjectUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/utils/PsiQuteProjectUtils.java
@@ -14,6 +14,8 @@ package com.redhat.devtools.intellij.qute.psi.utils;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
 import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.intellij.qute.psi.internal.QuteJavaConstants;
@@ -120,5 +122,10 @@ public class PsiQuteProjectUtils {
 		if (!segment.endsWith("/")) {
 			path.append('/');
 		}
+	}
+
+	public static boolean isQuteTemplate(VirtualFile file, Module module) {
+		return file.getPath().contains("templates") &&
+				ModuleRootManager.getInstance(module).getFileIndex().isInSourceContent(file);
 	}
 }

--- a/src/main/resources/META-INF/lsp4ij-quarkus.xml
+++ b/src/main/resources/META-INF/lsp4ij-quarkus.xml
@@ -1,7 +1,7 @@
 <idea-plugin>
   <extensions defaultExtensionNs="com.redhat.devtools.intellij.quarkus">
     <!-- Quarkus LSP -->
-    <server id="quarkus"
+    <server id="microprofile"
             label="Tools for MicroProfile"
             class="com.redhat.devtools.intellij.quarkus.lsp.QuarkusServer"
             clientImpl="com.redhat.devtools.intellij.quarkus.lsp.QuarkusLanguageClient"
@@ -17,9 +17,13 @@
         ]]>
       </description>
     </server>
-    <languageMapping language="Properties" serverId="quarkus"/>
-    <languageMapping language="JAVA" serverId="quarkus"/>
-    <serverIconProvider serverId="quarkus" class="com.redhat.devtools.intellij.microprofile.lang.MicroProfileServerIconProvider" />
+    <languageMapping language="Properties"
+                     serverId="microprofile"
+                     documentMatcher="com.redhat.devtools.intellij.quarkus.lsp.QuarkusDocumentMatcherForPropertiesFile" />
+    <languageMapping language="JAVA"
+                     serverId="microprofile"
+                     documentMatcher="com.redhat.devtools.intellij.quarkus.lsp.QuarkusDocumentMatcherForJavaFile"/>
+    <serverIconProvider serverId="microprofile" class="com.redhat.devtools.intellij.microprofile.lang.MicroProfileServerIconProvider" />
   </extensions>
 
   <extensions defaultExtensionNs="com.intellij">

--- a/src/main/resources/META-INF/lsp4ij-qute.xml
+++ b/src/main/resources/META-INF/lsp4ij-qute.xml
@@ -17,8 +17,12 @@
         ]]>
       </description>
     </server>
-    <languageMapping language="Qute_" serverId="qute"/>
-    <languageMapping language="JAVA" serverId="qute"/>
+    <languageMapping language="Qute_"
+                     serverId="qute"
+                     documentMatcher="com.redhat.devtools.intellij.qute.lsp.QuteDocumentMatcherForTemplateFile"/>
+    <languageMapping language="JAVA"
+                     serverId="qute"
+                     documentMatcher="com.redhat.devtools.intellij.qute.lsp.QuteDocumentMatcherForJavaFile"/>
     <serverIconProvider serverId="qute" class="com.redhat.devtools.intellij.quarkus.lang.QuarkusServerIconProvider" />
   </extensions>
 

--- a/src/test/java/com/redhat/devtools/intellij/quarkus/completion/MavenApplicationPropertiesCompletionTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/quarkus/completion/MavenApplicationPropertiesCompletionTest.java
@@ -17,6 +17,7 @@ import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.intellij.MavenEditorTest;
+import com.redhat.devtools.intellij.lsp4ij.ConnectDocumentToLanguageServerSetupParticipant;
 import org.junit.Test;
 
 import java.io.File;
@@ -30,6 +31,7 @@ public class MavenApplicationPropertiesCompletionTest extends MavenEditorTest {
 
 	@Test
 	public void testBooleanCompletion() throws Exception {
+
 		Module module = createMavenModule(new File("projects/quarkus/projects/maven/config-quickstart"));
 		VirtualFile propertiesFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module) + "/src/main/resources/application.properties");
 		codeInsightTestFixture.configureFromExistingVirtualFile(propertiesFile);


### PR DESCRIPTION
feat: Check if project is a MicroProfile, Qute, etc project to map file with a language server

Fixes #850
Fixes #1121

This PR provides a new API `DocumentMatcher` which is used to match the document with a language server. This matcher is called if the file language is mapped with a language server. Once language is matched, teh document filter is processed to have more robust filter:

 * for properties file, we check the  name of properties files which fixes #1121
 * for Java file, we check that the file belong to a Quarkus / Qute project. It means that if you have a java project which is not a Qute / Quarkus project, language server should never started
 * for HTML files, we check that html files belongs to templates folder and belong to a Qute project.

The `DocumentMatcher` is used for the moment only when file is opened,it means if we add / remove a Qute / Quarkus dependency, it will change nothing. You will need to close all files and reoping it. @fbricon perhaps we could see that in an another PR?