### PR TITLE
fix(auto-complete): added missing validate value to hibernate auto-complete

### DIFF
--- a/src/main/resources/static-properties/quarkus-hibernate-orm-metadata.json
+++ b/src/main/resources/static-properties/quarkus-hibernate-orm-metadata.json
@@ -21,6 +21,10 @@
 				{
 					"value": "update",
 					"description": "Update the schema if necessary."
+				},
+				{
+					"value": "validate",
+					"description": "Validate the schema."
 				}
 			],
 			"name": "quarkus.hibernate-orm.database.generation"


### PR DESCRIPTION
This PR adds a missing value to quarkus.hibernate-orm.database.generation.

While addressing this issue, I searched for references and discovered a test: [MavenQuarkusHibernateORMPropertyTest](https://github.com/redhat-developer/intellij-quarkus/blob/main/src/test/java/com/redhat/microprofile/psi/quarkus/MavenQuarkusHibernateORMPropertyTest.java). There is a description value which includes ```Accepted values:``` and is also missing ```validate``` value. Since I couldn't determine where the test pulls its expected values from, I was unable to add the missing value ```validate```