### PR TITLE
fix: Prevent from telemetry crash when language servers starts

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusServer.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusServer.java
@@ -14,11 +14,12 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
-import com.redhat.devtools.intellij.lsp4mp4ij.settings.MicroProfileInspectionsInfo;
-import com.redhat.devtools.intellij.quarkus.TelemetryService;
 import com.redhat.devtools.intellij.lsp4ij.server.JavaProcessCommandBuilder;
 import com.redhat.devtools.intellij.lsp4ij.server.ProcessStreamConnectionProvider;
 import com.redhat.devtools.intellij.lsp4mp4ij.settings.UserDefinedMicroProfileSettings;
+import com.redhat.devtools.intellij.quarkus.TelemetryService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URI;
@@ -32,6 +33,8 @@ import java.util.Map;
  */
 public class QuarkusServer extends ProcessStreamConnectionProvider {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(QuarkusServer.class);
+
     private final Project project;
 
     public QuarkusServer(Project project) {
@@ -40,14 +43,18 @@ public class QuarkusServer extends ProcessStreamConnectionProvider {
         File lsp4mpServerPath = new File(descriptor.getPath(), "lib/server/org.eclipse.lsp4mp.ls-uber.jar");
         File quarkusServerPath = new File(descriptor.getPath(), "lib/server/com.redhat.quarkus.ls.jar");
 
-        List<String> commands = new JavaProcessCommandBuilder(project,"quarkus")
+        List<String> commands = new JavaProcessCommandBuilder(project, "quarkus")
                 .setJar(lsp4mpServerPath.getAbsolutePath())
                 .setCp(quarkusServerPath.getAbsolutePath())
                 .create();
         commands.add("-DrunAsync=true");
         super.setCommands(commands);
 
-        TelemetryService.instance().action(TelemetryService.LSP_PREFIX + "start").send();
+        try {
+            TelemetryService.instance().action(TelemetryService.LSP_PREFIX + "start").send();
+        } catch (Exception e) {
+            LOGGER.error("Error while consuming telemetry service", e);
+        }
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteServer.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteServer.java
@@ -14,12 +14,12 @@ import com.intellij.ide.plugins.IdeaPluginDescriptor;
 import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
-import com.redhat.devtools.intellij.lsp4mp4ij.settings.UserDefinedMicroProfileSettings;
-import com.redhat.devtools.intellij.quarkus.TelemetryService;
 import com.redhat.devtools.intellij.lsp4ij.server.JavaProcessCommandBuilder;
 import com.redhat.devtools.intellij.lsp4ij.server.ProcessStreamConnectionProvider;
-import com.redhat.devtools.intellij.qute.settings.QuteInspectionsInfo;
+import com.redhat.devtools.intellij.quarkus.TelemetryService;
 import com.redhat.devtools.intellij.qute.settings.UserDefinedQuteSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.net.URI;
@@ -32,6 +32,8 @@ import java.util.Map;
  * Start the Qute language server process.
  */
 public class QuteServer extends ProcessStreamConnectionProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(QuteServer.class);
 
     private final Project project;
 
@@ -46,7 +48,12 @@ public class QuteServer extends ProcessStreamConnectionProvider {
         commands.add("-DrunAsync=true");
         super.setCommands(commands);
 
-        TelemetryService.instance().action(TelemetryService.LSP_PREFIX + "startQute").send();
+        try {
+            TelemetryService.instance().action(TelemetryService.LSP_PREFIX + "startQute").send();
+        }
+        catch(Exception e) {
+            LOGGER.error("Error while consuming telemetry service", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
In EAP, tlemetry is unloaded (I need to investigate that) and when language servers are started the telemetry crashes. This PR catch the the call of telemetry to show the following stack trace and give the capability to start language servers even if telemetry crashes.

```
Error while consuming telemetry service

java.lang.NullPointerException: Cannot invoke "com.redhat.devtools.intellij.telemetry.core.service.TelemetryServiceFactory.create(java.lang.ClassLoader)" because "factory" is null
	at com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder$ServiceFacade.createService(TelemetryMessageBuilder.java:260)
	at com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder$ServiceFacade.send(TelemetryMessageBuilder.java:251)
	at com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder$Message.send(TelemetryMessageBuilder.java:236)
	at com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder$ActionMessage.send(TelemetryMessageBuilder.java:174)
	at com.redhat.devtools.intellij.qute.lsp.QuteServer.<init>(QuteServer.java:54)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at com.intellij.serviceContainer.ConstructorInjectionKt.instantiateUsingPicoContainer(constructorInjection.kt:95)
	at com.intellij.serviceContainer.ComponentManagerImpl.instantiateClassWithConstructorInjection(ComponentManagerImpl.kt:928)
	at com.redhat.devtools.intellij.lsp4ij.LanguageServersRegistry$ExtensionLanguageServerDefinition.createConnectionProvider(LanguageServersRegistry.java:131)
	at com.redhat.devtools.intellij.lsp4ij.LanguageServerWrapper.lambda$start$0(LanguageServerWrapper.java:316)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1760)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165)

```