### PR TITLE
perf: set read action allowed when file is opened

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/LanguageServiceAccessor.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/LanguageServiceAccessor.java
@@ -333,7 +333,7 @@ public class LanguageServiceAccessor {
     }
 
     private static boolean match(VirtualFile file, Project fileProject, ContentTypeToLanguageServerDefinition mapping) {
-        if (ApplicationManager.getApplication().isUnitTestMode()) {
+        if (!ApplicationManager.getApplication().isReadAccessAllowed()) {
             return ReadAction.compute(() -> mapping.match(file, fileProject));
         }
         return mapping.match(file, fileProject);


### PR DESCRIPTION
This PR tries to connect a file which is opened by setting the read action allowed (with non blocing read action) by keeping checking that index is finished (to start language server).

As document matcher requires read action, we are sure that when a file is opened, the read action is allowed.