### PR TITLE
fix: call init when open file must start ls while indexing.

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/ConnectDocumentToLanguageServerSetupParticipant.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/ConnectDocumentToLanguageServerSetupParticipant.java
@@ -38,6 +38,7 @@ public class ConnectDocumentToLanguageServerSetupParticipant implements ProjectM
                 connectToLanguageServer(file, project);
                 return null;
             }, MessageFormat.format(MESSAGE_KEY, file.getUrl()), project, null, new CoalesceByKey(ConnectDocumentToLanguageServerSetupParticipant.class.getName(), file.getUrl()));
+            init();
         }
     }
 


### PR DESCRIPTION
fix: call init when open file must start ls while indexing.