### PR TITLE
fix: prevent NPE when calling ConsoleContentPanel.showMessage

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/LSPConsoleToolWindowPanel.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/console/LSPConsoleToolWindowPanel.java
@@ -246,10 +246,16 @@ public class LSPConsoleToolWindowPanel extends SimpleToolWindowPanel implements 
         }
 
         public void showMessage(String message) {
+            if (consoleView == null) {
+                return;
+            }
             consoleView.print(message, ConsoleViewContentType.SYSTEM_OUTPUT);
         }
 
         public void showError(Throwable exception) {
+            if (consoleView == null) {
+                return;
+            }
             String stacktrace = getStackTrace(exception);
             consoleView.print(stacktrace, ConsoleViewContentType.ERROR_OUTPUT);
         }


### PR DESCRIPTION
Fixes rare NPE:

```
java.lang.NullPointerException: Cannot invoke “com.intellij.execution.ui.ConsoleView.print(String, com.intellij.execution.ui.ConsoleViewContentType)” because “this.consoleView” is null
	at com.redhat.devtools.intellij.lsp4ij.console.LSPConsoleToolWindowPanel$ConsoleContentPanel.showMessage(LSPConsoleToolWindowPanel.java:249)
[15:05](https://redhat-internal.slack.com/archives/DK4SDAQJH/p1697634348846939)
```