### PR TITLE
fix: disallow language servers in light edit mode

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/ContentTypeToLanguageServerDefinition.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/ContentTypeToLanguageServerDefinition.java
@@ -20,7 +20,7 @@ public class ContentTypeToLanguageServerDefinition extends AbstractMap.SimpleEnt
     }
 
     public boolean match(VirtualFile file, Project project) {
-        return documentMatcher.match(file, project);
+        return getValue().supportsCurrentEditMode(project) && documentMatcher.match(file, project);
     }
 
     public boolean shouldBeMatchedAsynchronously(Project project) {
@@ -32,6 +32,9 @@ public class ContentTypeToLanguageServerDefinition extends AbstractMap.SimpleEnt
     }
 
     public @NotNull <R> CompletableFuture<Boolean> matchAsync(VirtualFile file, Project project) {
+        if (!getValue().supportsCurrentEditMode(project)) {
+            return CompletableFuture.completedFuture(false);
+        }
         return documentMatcher.matchAsync(file, project);
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/ServerExtensionPointBean.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/ServerExtensionPointBean.java
@@ -42,6 +42,9 @@ public class ServerExtensionPointBean extends BaseKeyedLazyInstance<StreamConnec
     @Attribute("singleton")
     public boolean singleton;
 
+    @Attribute("supportsLightEdit")
+    public boolean supportsLightEdit;
+
     @Attribute("lastDocumentDisconnectedTimeout")
     public Integer lastDocumentDisconnectedTimeout;
 

--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/internal/PromiseToCompletableFuture.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/internal/PromiseToCompletableFuture.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.lsp4ij.internal;
 
+import com.intellij.ide.lightEdit.LightEdit;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.progress.EmptyProgressIndicator;
@@ -74,8 +75,8 @@ public class PromiseToCompletableFuture<R> extends CompletableFuture<R> {
     }
 
     protected void init() {
-        // if indexation is processing, we need to execute the promise in smart mode
-        var executeInSmartMode = DumbService.getInstance(project).isDumb();
+        // if indexation is processing and not in Light Edit mode, we need to execute the promise in smart mode
+        var executeInSmartMode =  !LightEdit.owns(project) && DumbService.getInstance(project).isDumb();
         var promise = nonBlockingReadActionPromise(executeInSmartMode);
         bind(promise);
     }


### PR DESCRIPTION
- don't use smart mode when in light edit
- added new supportsLightEdit property to LS definitions, so some LS can be allowed in Light Edit mode. Disabled by default, so no Quarkus nor Qute LS are spawned in Light Edit mode

Fixes #1244 

To test this fix, you need to install the corresponding build in the IDEA installation used to open a java file on double-click, or via `idea <filename>.java` in a terminal