### PR TITLE
fix: ignore non-local files in LSPDocumentationProvider#handleExternalLink

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4ij/operations/documentation/LSPDocumentationProvider.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4ij/operations/documentation/LSPDocumentationProvider.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
+import com.intellij.util.io.URLUtil;
 import com.redhat.devtools.intellij.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.intellij.lsp4ij.operations.completion.LSPCompletionProposal;
 import com.vladsch.flexmark.html.HtmlRenderer;
@@ -146,6 +147,10 @@ public class LSPDocumentationProvider extends DocumentationProviderEx implements
 
     @Override
     public boolean handleExternalLink(PsiManager psiManager, String link, PsiElement context) {
+        //Ignore non-local uri (http(s), mailto, ftp...)
+        if (URLUtil.URL_PATTERN.matcher(link).matches()) {
+            return false;
+        }
         VirtualFile file = LSPIJUtils.findResourceFor(link);
         if (file != null) {
             FileEditorManager.getInstance(psiManager.getProject()).openFile(file, true, true);


### PR DESCRIPTION
To reproduce, scroll down to bottom of the String Javadoc, the click on the link.

Before the fix:
![Nov-06-2023 14-07-40](https://github.com/redhat-developer/intellij-quarkus/assets/148698/f9db7715-ee0f-4068-bffd-5bce89cd36ce)

After the fix:
![Nov-06-2023 14-10-11](https://github.com/redhat-developer/intellij-quarkus/assets/148698/3052f6f8-a235-4d1e-91a4-b22deceb3392)

This also prevents an exception:

```
java.lang.Throwable: Write-unsafe context! Model changes are allowed from write-safe contexts only. Please ensure you're using invokeLater/invokeAndWait with a correct modality state (not "any"). See TransactionGuard documentation for details.
  current modality=ModalityState.NON_MODAL
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:184)
	at com.intellij.openapi.application.TransactionGuardImpl.assertWriteActionAllowed(TransactionGuardImpl.java:135)
	at com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl.openFileImpl4Edt(FileEditorManagerImpl.java:975)
	at com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl.lambda$openFileImpl4$17(FileEditorManagerImpl.java:961)
	at com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl.runBulkTabChange(FileEditorManagerImpl.java:1698)
	at com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl.lambda$openFileImpl4$18(FileEditorManagerImpl.java:960)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:492)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:525)
	at com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl.openFileImpl4(FileEditorManagerImpl.java:957)
	at com.jetbrains.rdserver.fileEditors.BackendServerFileEditorManager.openFileImpl4(BackendServerFileEditorManager.kt:34)
	at com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl.lambda$openFileImpl2$14(FileEditorManagerImpl.java:885)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:219)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:174)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:164)
	at com.intellij.openapi.command.impl.CoreCommandProcessor.executeCommand(CoreCommandProcessor.java:150)
	at com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl.openFileImpl2(FileEditorManagerImpl.java:884)
	at com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl.openFileWithProviders(FileEditorManagerImpl.java:765)
	at com.intellij.openapi.fileEditor.impl.FileEditorManagerImpl.openFileWithProviders(FileEditorManagerImpl.java:725)
	at com.intellij.openapi.fileEditor.ex.FileEditorManagerEx.openFile(FileEditorManagerEx.java:127)
	at com.redhat.devtools.intellij.lsp4ij.operations.documentation.LSPDocumentationProvider.handleExternalLink(LSPDocumentationProvider.java:152)
	at com.intellij.lang.documentation.ide.impl.LinksKt.doHandleExternal(links.kt:74)
	at com.intellij.lang.documentation.ide.impl.LinksKt.handleExternal(links.kt:62)
	at com.intellij.lang.documentation.ide.impl.LinksKt.openUrl(links.kt:51)
	at com.intellij.lang.documentation.ide.impl.DocumentationBrowser$handleLink$3.invokeSuspend(DocumentationBrowser.kt:130)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:194)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:881)
	at com.intellij.openapi.application.impl.ApplicationImpl$3.run(ApplicationImpl.java:513)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:75)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:118)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:42)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:792)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:739)
	at java.desktop/java.awt.EventQueue$3.run(EventQueue.java:733)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:761)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:918)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:766)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$6(IdeEventQueue.java:450)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:791)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$7(IdeEventQueue.java:449)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:105)
	at com.intellij.ide.IdeEventQueue.performActivity(IdeEventQueue.java:624)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:447)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:881)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:493)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
```

Fixes #1254 