### PR TITLE
fix: Copy 'Run launch' tasks to the Maven run configuration

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/gradle/AbstractGradleToolDelegate.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/gradle/AbstractGradleToolDelegate.java
@@ -365,6 +365,7 @@ public abstract class AbstractGradleToolDelegate implements ToolDelegate {
             parameters += " -Dquarkus.profile=" + configuration.getProfile();
         }
         gradleConfiguration.getSettings().setScriptParameters(parameters);
+        gradleConfiguration.setBeforeRunTasks(configuration.getBeforeRunTasks());
         return settings;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/maven/MavenToolDelegate.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/maven/MavenToolDelegate.java
@@ -252,6 +252,7 @@ public class MavenToolDelegate implements ToolDelegate {
             mavenConfiguration.getRunnerSettings().getMavenProperties().put("quarkus.profile", configuration.getProfile());
         }
         mavenConfiguration.getRunnerSettings().getMavenProperties().put("debug", Integer.toString(configuration.getPort()));
+        mavenConfiguration.setBeforeRunTasks(configuration.getBeforeRunTasks());
         return settings;
     }
 


### PR DESCRIPTION
The 'Before launch' tasks are configured in the QuarkusRunConfiguration. The must be added to the MavenRunConfiguration and GradleRunConfiguration, which are the ones which are actually executed.

Fixes #1259