### PR TITLE
fix: retain input on wizard page back navigation

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusExtensionsModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusExtensionsModel.java
@@ -10,19 +10,15 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.quarkus.projectWizard;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class QuarkusExtensionsModel {
     private final String key;
-    private List<QuarkusCategory> categories = new ArrayList<>();
+    private final List<QuarkusCategory> categories = new ArrayList<>();
 
     public QuarkusExtensionsModel(String key, List<QuarkusExtension> extensions) {
         this.key = key;
-        Collections.sort(extensions, (e1, e2) -> e1.getOrder() - e2.getOrder());
+        extensions.sort(Comparator.comparingInt(QuarkusExtension::getOrder));
         Map<String, QuarkusExtension> extensionIds = new HashMap<>();
         final QuarkusCategory[] currentCategory = {null};
         extensions.forEach(e -> {

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusExtensionsStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusExtensionsStep.java
@@ -53,6 +53,7 @@ public class QuarkusExtensionsStep extends ModuleWizardStep implements Disposabl
 
     private JPanel outerPanel;
     private final WizardContext wizardContext;
+    private SearchTextField filter;
 
     private static class ExtensionsTreeCellRenderer extends CheckboxTree.CheckboxTreeCellRenderer {
 
@@ -135,7 +136,7 @@ public class QuarkusExtensionsStep extends ModuleWizardStep implements Disposabl
             JLabel label1 = new JLabel("Filter extensions");
             label1.setAlignmentX(Component.LEFT_ALIGNMENT);
             panel.add(label1);
-            SearchTextField filter = new SearchTextField() {
+            filter = new SearchTextField() {
                 @Override
                 public Dimension getMaximumSize() {
                     Dimension maxSize = super.getMaximumSize();
@@ -221,6 +222,12 @@ public class QuarkusExtensionsStep extends ModuleWizardStep implements Disposabl
             outerPanel.add(panel, BorderLayout.CENTER);
         }
         return outerPanel;
+    }
+
+
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return filter;
     }
 
     private KeyListener onSelectedExtensionsKeyPressed(List<QuarkusCategory> categories, CheckboxTree extensionsTree, JList<QuarkusExtension> selectedExtensions) {

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusExtensionsStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusExtensionsStep.java
@@ -257,7 +257,6 @@ public class QuarkusExtensionsStep extends ModuleWizardStep implements Disposabl
                             // so we force it manually
                             selectedExtensions.setModel(new SelectedExtensionsModel(categories));
                         }
-                        ;
                     }
                 }
             }

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusModel.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusModel.java
@@ -21,11 +21,11 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
 public class QuarkusModel implements Disposable {
-    private String baseURL;
+    private final String baseURL;
 
-    private List<QuarkusStream> streams;
+    private final List<QuarkusStream> streams;
 
-    private Map<String, QuarkusExtensionsModel> extensionsModelMap = new HashMap<>();
+    private final Map<String, QuarkusExtensionsModel> extensionsModelMap = new HashMap<>();
 
     public QuarkusModel(String baseURL, List<QuarkusStream> streams) {
         this.baseURL = baseURL;

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusModuleInfoStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusModuleInfoStep.java
@@ -202,6 +202,11 @@ public class QuarkusModuleInfoStep extends ModuleWizardStep implements Disposabl
         isInitialized = true;
     }
 
+    @Override
+    public JComponent getPreferredFocusedComponent() {
+        return toolComboBox;
+    }
+
     private Future<QuarkusExtensionsModel> loadExtensionsModel(CollectionComboBoxModel<QuarkusStream> streamModel, ProgressIndicator indicator) {
         String key = ((QuarkusStream) streamModel.getSelectedItem()).getKey();
         if (key == null) {

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusModuleInfoStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusModuleInfoStep.java
@@ -74,7 +74,7 @@ public class QuarkusModuleInfoStep extends ModuleWizardStep implements Disposabl
 
     private JBTextField pathField;
 
-    private AsyncProcessIcon spinner = new AsyncProcessIcon(QuarkusBundle.message("quarkus.wizard.loading.extensions"));
+    private final AsyncProcessIcon spinner = new AsyncProcessIcon(QuarkusBundle.message("quarkus.wizard.loading.extensions"));
 
     private final WizardContext context;
 
@@ -85,6 +85,8 @@ public class QuarkusModuleInfoStep extends ModuleWizardStep implements Disposabl
     private QuarkusExtensionsModel extensionsModel;
     private CollectionComboBoxModel<QuarkusStream> streamModel;
     private EmptyProgressIndicator indicator;
+
+    private boolean isInitialized = false;
 
     public QuarkusModuleInfoStep(WizardContext context) {
         Disposer.register(context.getDisposable(), this);
@@ -107,7 +109,6 @@ public class QuarkusModuleInfoStep extends ModuleWizardStep implements Disposabl
         context.putUserData(QuarkusConstants.WIZARD_PATH_KEY, pathField.getText());
         context.putUserData(QuarkusConstants.WIZARD_EXTENSIONS_MODEL_KEY, extensionsModel);
     }
-
     @Override
     public void dispose() {
         if (model != null) {
@@ -122,6 +123,9 @@ public class QuarkusModuleInfoStep extends ModuleWizardStep implements Disposabl
 
     @Override
     public void _init() {
+        if (isInitialized) {
+            return;
+        }
         panel.setBorder(JBUI.Borders.empty(20));
 
         indicator = new EmptyProgressIndicator() {
@@ -195,6 +199,7 @@ public class QuarkusModuleInfoStep extends ModuleWizardStep implements Disposabl
         panel.add(ScrollPaneFactory.createScrollPane(formBuilder.getPanel(), true), "North");
         hideSpinner();
         extensionsModelRequest = loadExtensionsModel(streamModel, indicator);
+        isInitialized = true;
     }
 
     private Future<QuarkusExtensionsModel> loadExtensionsModel(CollectionComboBoxModel<QuarkusStream> streamModel, ProgressIndicator indicator) {


### PR DESCRIPTION
If you try to create a new Quarkus project with the wizard, set the name to "foobar", go to the last page, the project name and location are set to "foobar". Now if you go back and change the artifactId to "barfoo", on the last page, the name and location are reset to "code-with-quarkus". Additionally, any other changes made on the module info step page are lost (eg. if you changed the build to gradle, the generated project will use Maven)

This PR fixes this issue by avoiding the reinitialization of UI components in QuarkusModuleInfoStep._init()

