### PR TITLE
fix: keep compatibility with 2023.3

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/maven/MavenToolDelegate.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/maven/MavenToolDelegate.java
@@ -93,8 +93,9 @@ public class MavenToolDelegate implements BuildToolDelegate {
             var distributionUrl = getWrapperDistributionUrl(ProjectUtil.guessProjectDir(project));
             if (distributionUrl != null) {
                 String mavenHome = mavenSettings.getMavenHome();
-                if (!MavenServerManager.WRAPPED_MAVEN.equals(mavenHome)){
-                    mavenSettings.setMavenHome(MavenServerManager.WRAPPED_MAVEN);
+                String WRAPPED_MAVEN = "Use Maven wrapper"; //MavenServerManager.WRAPPED_MAVEN was removed in 2023.3 without any deprecation warning!
+                if (!WRAPPED_MAVEN.equals(mavenHome)){
+                    mavenSettings.setMavenHome(WRAPPED_MAVEN);
                 }
             }
         }


### PR DESCRIPTION
MavenServerManager.WRAPPED_MAVEN was removed in 2023.3 without any deprecation warning, so we keep a local copy

Signed-off-by: Fred Bricon <fbricon@gmail.com>
