### PR TITLE
fix: log YAML parsing errors as warning to avoid popup

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/project/AbstractConfigSource.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/project/AbstractConfigSource.java
@@ -176,13 +176,13 @@ public abstract class AbstractConfigSource<T> implements IConfigSource {
                 try (InputStream input = configFile.getInputStream()) {
                     config = loadConfig(input);
                     lastModified = configFile.getModificationStamp();
-                } catch (IOException e) {
+                } catch (Exception e) {
                     reset();
-                    LOGGER.error("Error while loading properties from '" + configFile + "'.", e);
+                    LOGGER.warn("Error while loading properties from '" + configFile + "'.", e);
                 }
             }
         } catch (RuntimeException e1) {
-            LOGGER.error("Error while getting last modified time for '" + configFile + "'.", e1);
+            LOGGER.warn("Error while getting last modified time for '" + configFile + "'.", e1);
         }
         return config;
     }
@@ -194,9 +194,9 @@ public abstract class AbstractConfigSource<T> implements IConfigSource {
         try (InputStream input = IOUtils.toInputStream(content, Charset.defaultCharset())) {
             config = loadConfig(input);
             lastModified = System.currentTimeMillis();
-        } catch (IOException e) {
+        } catch (Exception e) {
             reset();
-            LOGGER.error("Error while loading properties from '" + sourceConfigFile + "'.", e);
+            LOGGER.warn("Error while loading properties from '" + sourceConfigFile + "'.", e);
         }
     }
 
@@ -207,7 +207,7 @@ public abstract class AbstractConfigSource<T> implements IConfigSource {
             try {
                 return Integer.parseInt(property.trim());
             } catch (NumberFormatException e) {
-                LOGGER.error("Error while converting '" + property.trim() + "' as Integer for key '" + key + "'", e);
+                LOGGER.warn("Error while converting '" + property.trim() + "' as Integer for key '" + key + "'", e);
                 return null;
             }
         }


### PR DESCRIPTION
Since 2022.3 apparently, log events with error severity now bubble up as error popups in a user's face.
 
This PR fixes #1282 until we drop SnakeYAML for good, but most likely other places where a log.error is met will have the same issue
