### PR TITLE
fix: use JSONUtils from LSP4IJ

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/MicroProfileConfigConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/MicroProfileConfigConstants.java
@@ -50,9 +50,5 @@ public class MicroProfileConfigConstants {
 
 	public static final String COMPLETION_STAGE_TYPE_UTILITY = "java.util.concurrent.CompletionStage";
 
-	// Diagnostic data
-
-	public static final String DIAGNOSTIC_DATA_NAME = "name";
-
 	public static final String UNI_TYPE_UTILITY = "io.smallrye.mutiny.Uni";
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/command/MicroprofileOpenURIAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/command/MicroprofileOpenURIAction.java
@@ -3,32 +3,28 @@ package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.command;
 import com.google.gson.JsonPrimitive;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.redhat.devtools.lsp4ij.commands.LSPCommand;
 import com.redhat.devtools.lsp4ij.commands.LSPCommandAction;
-import org.eclipse.lsp4j.Command;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.List;
 
 public class MicroprofileOpenURIAction extends LSPCommandAction {
 
     @Override
-    protected void commandPerformed(@NotNull Command command, @NotNull AnActionEvent anActionEvent) {
-        String url = getURL(command.getArguments());
+    protected void commandPerformed(@NotNull LSPCommand command, @NotNull AnActionEvent anActionEvent) {
+        String url = getURL(command);
         if (url != null) {
             BrowserUtil.browse(url);
         }
     }
 
-    private String getURL(List<Object> arguments) {
-        String url = null;
-        if (!arguments.isEmpty()) {
-            Object arg = arguments.get(0);
-            if (arg instanceof JsonPrimitive) {
-                url = ((JsonPrimitive) arg).getAsString();
-            } else if (arg instanceof String) {
-                url = (String) arg;
-            }
+    private String getURL(LSPCommand command) {
+        Object arg = command.getArgumentAt(0);
+        if (arg instanceof JsonPrimitive) {
+            return ((JsonPrimitive) arg).getAsString();
         }
-        return url;
+        if (arg instanceof String) {
+            return (String) arg;
+        }
+        return null;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/command/MicroprofileUpdateConfigurationAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/command/MicroprofileUpdateConfigurationAction.java
@@ -25,6 +25,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.impl.FakePsiElement;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections.MicroProfilePropertiesUnassignedInspection;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.inspections.MicroProfilePropertiesUnknownInspection;
+import com.redhat.devtools.lsp4ij.commands.LSPCommand;
 import com.redhat.devtools.lsp4ij.commands.LSPCommandAction;
 import com.redhat.devtools.lsp4ij.inspections.AbstractDelegateInspectionWithExclusions;
 import org.eclipse.lsp4j.Command;
@@ -47,7 +48,7 @@ public class MicroprofileUpdateConfigurationAction extends LSPCommandAction {
     }
 
     @Override
-    protected void commandPerformed(@NotNull Command command, @NotNull AnActionEvent e) {
+    protected void commandPerformed(@NotNull LSPCommand command, @NotNull AnActionEvent e) {
         JsonObject configUpdate = getConfigUpdate(command);
         if (configUpdate != null && e.getProject() != null) {
             String section = configUpdate.get("section").getAsString();
@@ -60,13 +61,10 @@ public class MicroprofileUpdateConfigurationAction extends LSPCommandAction {
         }
     }
 
-    private @Nullable JsonObject getConfigUpdate(@NotNull Command command) {
-        List<Object> arguments = command.getArguments();
-        if (arguments != null && !arguments.isEmpty()) {
-            Object arg = arguments.get(0);
-            if (arg instanceof JsonObject) {
-                return (JsonObject) arg;
-            }
+    private @Nullable JsonObject getConfigUpdate(@NotNull LSPCommand command) {
+        Object arg = command.getArgumentAt(0);
+        if (arg instanceof JsonObject) {
+            return (JsonObject) arg;
         }
         return null;
     }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/config/java/MicroProfileConfigASTValidator.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/config/java/MicroProfileConfigASTValidator.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.config.java;
 
-import com.google.gson.JsonObject;
 import com.intellij.openapi.module.Module;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -36,17 +35,13 @@ import java.util.List;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileConfigConstants.CONFIG_PROPERTIES_ANNOTATION;
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileConfigConstants.CONFIG_PROPERTY_ANNOTATION;
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileConfigConstants.CONFIG_PROPERTY_ANNOTATION_NAME;
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileConfigConstants.DIAGNOSTIC_DATA_NAME;
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileConfigConstants.MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE;
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileConfigConstants.*;
 import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils.getAnnotationMemberValueExpression;
 
 /**
  * Collects diagnostics related to the <code>@ConfigProperty</code> annotation
  * in a Java file.
- *
+ * <p>
  * Produces diagnostics when:
  * <ul>
  * <li>The <code>defaultValue</code> attribute value cannot be represented by
@@ -54,250 +49,247 @@ import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUt
  * <li>The config property defined by the annotation doesn't have a default
  * value and doesn't have a value assigned to it in any properties file</li>
  * </ul>
- *
  */
 public class MicroProfileConfigASTValidator extends JavaASTValidator {
 
-	private static final Logger LOGGER = Logger.getLogger(MicroProfileConfigASTValidator.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(MicroProfileConfigASTValidator.class.getName());
 
-	private static final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private static final AntPathMatcher pathMatcher = new AntPathMatcher();
 
-	private static final Pattern ARRAY_SPLITTER = Pattern.compile("(?<!\\\\),");
+    private static final Pattern ARRAY_SPLITTER = Pattern.compile("(?<!\\\\),");
 
-	private static final String EXPECTED_TYPE_ERROR_MESSAGE = "''{0}'' does not match the expected type of ''{1}''.";
+    private static final String EXPECTED_TYPE_ERROR_MESSAGE = "''{0}'' does not match the expected type of ''{1}''.";
 
-	private static final String EMPTY_LIST_LIKE_WARNING_MESSAGE = "''defaultValue=\"\"'' will behave as if no default value is set, and will not be treated as an empty ''{0}''.";
+    private static final String EMPTY_LIST_LIKE_WARNING_MESSAGE = "''defaultValue=\"\"'' will behave as if no default value is set, and will not be treated as an empty ''{0}''.";
 
-	private static final String NO_VALUE_ERROR_MESSAGE = "The property ''{0}'' is not assigned a value in any config file, and must be assigned at runtime.";
+    private static final String NO_VALUE_ERROR_MESSAGE = "The property ''{0}'' is not assigned a value in any config file, and must be assigned at runtime.";
 
-	private static final String EMPTY_KEY_ERROR_MESSAGE = "The member ''{0}'' can'''t be empty.";
+    private static final String EMPTY_KEY_ERROR_MESSAGE = "The member ''{0}'' can'''t be empty.";
 
-	private List<String> patterns;
-	// prefix from @ConfigProperties(prefix="")
-	private String currentPrefix;
+    private List<String> patterns;
+    // prefix from @ConfigProperties(prefix="")
+    private String currentPrefix;
 
-	@Override
-	public void initialize(JavaDiagnosticsContext context, List<Diagnostic> diagnostics) {
-		super.initialize(context, diagnostics);
-		this.currentPrefix = null;
-		this.patterns = getPatternsFromContext(context);
-	}
+    @Override
+    public void initialize(JavaDiagnosticsContext context, List<Diagnostic> diagnostics) {
+        super.initialize(context, diagnostics);
+        this.currentPrefix = null;
+        this.patterns = getPatternsFromContext(context);
+    }
 
-	@Override
-	public boolean isAdaptedForDiagnostics(JavaDiagnosticsContext context) {
-		Module javaProject = context.getJavaProject();
-		return PsiTypeUtils.findType(javaProject, CONFIG_PROPERTY_ANNOTATION) != null;
-	}
+    @Override
+    public boolean isAdaptedForDiagnostics(JavaDiagnosticsContext context) {
+        Module javaProject = context.getJavaProject();
+        return PsiTypeUtils.findType(javaProject, CONFIG_PROPERTY_ANNOTATION) != null;
+    }
 
-	private static List<String> getPatternsFromContext(JavaDiagnosticsContext context) {
-		return context.getSettings().getPatterns();
-	}
+    private static List<String> getPatternsFromContext(JavaDiagnosticsContext context) {
+        return context.getSettings().getPatterns();
+    }
 
-	@Override
-	public void visitClass(PsiClass typeDeclaration) {
-		// Get prefix from @ConfigProperties(prefix="")
-		for(PsiAnnotation annotation : typeDeclaration.getAnnotations()) {
-			if (AnnotationUtils.isMatchAnnotation(annotation, CONFIG_PROPERTIES_ANNOTATION)) {
-				PsiAnnotationMemberValue prefixExpr = getAnnotationMemberValueExpression(annotation, MicroProfileConfigConstants.CONFIG_PROPERTIES_ANNOTATION_PREFIX);
-				if (prefixExpr instanceof PsiLiteral && ((PsiLiteral) prefixExpr).getValue() instanceof String) {
-					currentPrefix = (String) ((PsiLiteral) prefixExpr).getValue();
-				}
+    @Override
+    public void visitClass(PsiClass typeDeclaration) {
+        // Get prefix from @ConfigProperties(prefix="")
+        for (PsiAnnotation annotation : typeDeclaration.getAnnotations()) {
+            if (AnnotationUtils.isMatchAnnotation(annotation, CONFIG_PROPERTIES_ANNOTATION)) {
+                PsiAnnotationMemberValue prefixExpr = getAnnotationMemberValueExpression(annotation, MicroProfileConfigConstants.CONFIG_PROPERTIES_ANNOTATION_PREFIX);
+                if (prefixExpr instanceof PsiLiteral && ((PsiLiteral) prefixExpr).getValue() instanceof String) {
+                    currentPrefix = (String) ((PsiLiteral) prefixExpr).getValue();
+                }
 
-			} else if (AnnotationUtils.isMatchAnnotation(annotation, QuarkusConstants.CONFIG_PROPERTIES_ANNOTATION)) {
-				PsiAnnotationMemberValue prefixExpr = getAnnotationMemberValueExpression(annotation, QuarkusConstants.CONFIG_PROPERTIES_ANNOTATION_PREFIX);
-				if (prefixExpr instanceof PsiLiteral && ((PsiLiteral) prefixExpr).getValue() instanceof String) {
-					currentPrefix = (String) ((PsiLiteral) prefixExpr).getValue();
-				}
+            } else if (AnnotationUtils.isMatchAnnotation(annotation, QuarkusConstants.CONFIG_PROPERTIES_ANNOTATION)) {
+                PsiAnnotationMemberValue prefixExpr = getAnnotationMemberValueExpression(annotation, QuarkusConstants.CONFIG_PROPERTIES_ANNOTATION_PREFIX);
+                if (prefixExpr instanceof PsiLiteral && ((PsiLiteral) prefixExpr).getValue() instanceof String) {
+                    currentPrefix = (String) ((PsiLiteral) prefixExpr).getValue();
+                }
 
-			}
-		}
-		typeDeclaration.acceptChildren(this);
-		this.currentPrefix = null;
-	}
+            }
+        }
+        typeDeclaration.acceptChildren(this);
+        this.currentPrefix = null;
+    }
 
-	@Override
-	public void visitAnnotation(PsiAnnotation annotation) {
-		PsiField parent = PsiTreeUtil.getParentOfType(annotation, PsiField.class);
-		if (AnnotationUtils.isMatchAnnotation(annotation, CONFIG_PROPERTY_ANNOTATION) && parent != null) {
-			PsiAnnotationMemberValue defaultValueExpr = getAnnotationMemberValueExpression(annotation, MicroProfileConfigConstants.CONFIG_PROPERTY_ANNOTATION_DEFAULT_VALUE);
-			validatePropertyDefaultValue(annotation, defaultValueExpr, parent);
-			validatePropertyHasValue(annotation, defaultValueExpr);
-		}
+    @Override
+    public void visitAnnotation(PsiAnnotation annotation) {
+        PsiField parent = PsiTreeUtil.getParentOfType(annotation, PsiField.class);
+        if (AnnotationUtils.isMatchAnnotation(annotation, CONFIG_PROPERTY_ANNOTATION) && parent != null) {
+            PsiAnnotationMemberValue defaultValueExpr = getAnnotationMemberValueExpression(annotation, MicroProfileConfigConstants.CONFIG_PROPERTY_ANNOTATION_DEFAULT_VALUE);
+            validatePropertyDefaultValue(annotation, defaultValueExpr, parent);
+            validatePropertyHasValue(annotation, defaultValueExpr);
+        }
 
-	}
+    }
 
-	/**
-	 * Validate "defaultValue" attribute of <code>@ConfigProperty</code> and
-	 * generate diagnostics if "defaultValue" cannot be represented by the given
-	 * field type.
-	 *
-	 * See
-	 * https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/converters.asciidoc
-	 * for more details on default converters.
-	 *
-	 * @param annotation       the annotation to validate the defaultValue of
-	 * @param defaultValueExpr the default value expression, or null if no default
-	 *                         value is defined
-	 */
-	private void validatePropertyDefaultValue(PsiAnnotation annotation, PsiAnnotationMemberValue defaultValueExpr,
-											  PsiField parent) {
-		if (defaultValueExpr instanceof PsiLiteral && ((PsiLiteral) defaultValueExpr).getValue() instanceof String && parent != null) {
-			String defValue = (String) ((PsiLiteral) defaultValueExpr).getValue();
-			Module javaProject = getContext().getJavaProject();
-			PsiType fieldBinding = parent.getType();
-			if (fieldBinding != null && defValue != null) {
-				if (isListLike(fieldBinding) && defValue.isEmpty()) {
-					String message = MessageFormat.format(EMPTY_LIST_LIKE_WARNING_MESSAGE, fieldBinding.getPresentableText());
-					super.addDiagnostic(message, MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE, defaultValueExpr,
-							MicroProfileConfigErrorCode.EMPTY_LIST_NOT_SUPPORTED, DiagnosticSeverity.Warning);
-				}
-				if (!isAssignable(fieldBinding, javaProject, defValue)) {
-					String message = MessageFormat.format(EXPECTED_TYPE_ERROR_MESSAGE, defValue, fieldBinding.getPresentableText());
-					super.addDiagnostic(message, MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE, defaultValueExpr,
-							MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE, DiagnosticSeverity.Error);
-				}
-			}
-		}
-	}
+    /**
+     * Validate "defaultValue" attribute of <code>@ConfigProperty</code> and
+     * generate diagnostics if "defaultValue" cannot be represented by the given
+     * field type.
+     * <p>
+     * See
+     * https://github.com/eclipse/microprofile-config/blob/master/spec/src/main/asciidoc/converters.asciidoc
+     * for more details on default converters.
+     *
+     * @param annotation       the annotation to validate the defaultValue of
+     * @param defaultValueExpr the default value expression, or null if no default
+     *                         value is defined
+     */
+    private void validatePropertyDefaultValue(PsiAnnotation annotation, PsiAnnotationMemberValue defaultValueExpr,
+                                              PsiField parent) {
+        if (defaultValueExpr instanceof PsiLiteral && ((PsiLiteral) defaultValueExpr).getValue() instanceof String && parent != null) {
+            String defValue = (String) ((PsiLiteral) defaultValueExpr).getValue();
+            Module javaProject = getContext().getJavaProject();
+            PsiType fieldBinding = parent.getType();
+            if (fieldBinding != null && defValue != null) {
+                if (isListLike(fieldBinding) && defValue.isEmpty()) {
+                    String message = MessageFormat.format(EMPTY_LIST_LIKE_WARNING_MESSAGE, fieldBinding.getPresentableText());
+                    super.addDiagnostic(message, MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE, defaultValueExpr,
+                            MicroProfileConfigErrorCode.EMPTY_LIST_NOT_SUPPORTED, DiagnosticSeverity.Warning);
+                }
+                if (!isAssignable(fieldBinding, javaProject, defValue)) {
+                    String message = MessageFormat.format(EXPECTED_TYPE_ERROR_MESSAGE, defValue, fieldBinding.getPresentableText());
+                    super.addDiagnostic(message, MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE, defaultValueExpr,
+                            MicroProfileConfigErrorCode.DEFAULT_VALUE_IS_WRONG_TYPE, DiagnosticSeverity.Error);
+                }
+            }
+        }
+    }
 
-	/**
-	 * Generates diagnostics if the property that this <code>@ConfigProperty</code>
-	 * defines does not have a value assigned to it.
-	 *
-	 * @param annotation       the ConfigProperty annotation
-	 * @param defaultValueExpr the default value expression, or null if no default
-	 *                         value is defined
-	 */
-	private void validatePropertyHasValue(PsiAnnotation annotation, PsiAnnotationMemberValue defaultValueExpr) {
-			String name = null;
-			PsiAnnotationMemberValue nameExpression = getAnnotationMemberValueExpression(annotation,
-					CONFIG_PROPERTY_ANNOTATION_NAME);
-			boolean hasDefaultValue = defaultValueExpr != null;
+    /**
+     * Generates diagnostics if the property that this <code>@ConfigProperty</code>
+     * defines does not have a value assigned to it.
+     *
+     * @param annotation       the ConfigProperty annotation
+     * @param defaultValueExpr the default value expression, or null if no default
+     *                         value is defined
+     */
+    private void validatePropertyHasValue(PsiAnnotation annotation, PsiAnnotationMemberValue defaultValueExpr) {
+        String name = null;
+        PsiAnnotationMemberValue nameExpression = getAnnotationMemberValueExpression(annotation,
+                CONFIG_PROPERTY_ANNOTATION_NAME);
+        boolean hasDefaultValue = defaultValueExpr != null;
 
-			if (nameExpression instanceof PsiLiteral && ((PsiLiteral) nameExpression).getValue() instanceof String) {
-				name = (String) ((PsiLiteral) nameExpression).getValue();
-				name = MicroProfileConfigPropertyProvider.getPropertyName(name, currentPrefix);
-			}
+        if (nameExpression instanceof PsiLiteral && ((PsiLiteral) nameExpression).getValue() instanceof String) {
+            name = (String) ((PsiLiteral) nameExpression).getValue();
+            name = MicroProfileConfigPropertyProvider.getPropertyName(name, currentPrefix);
+        }
 
-		if (name != null) {
-			if (name.isEmpty()) {
-				String message = MessageFormat.format(EMPTY_KEY_ERROR_MESSAGE, CONFIG_PROPERTY_ANNOTATION_NAME);
-				Diagnostic d = super.addDiagnostic(message, MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE, nameExpression,
-						MicroProfileConfigErrorCode.EMPTY_KEY, DiagnosticSeverity.Error);
-			} else if (!hasDefaultValue && !doesPropertyHaveValue(name, getContext()) && !isPropertyIgnored(name)) {
-				String message = MessageFormat.format(NO_VALUE_ERROR_MESSAGE, name);
-				Diagnostic d = super.addDiagnostic(message, MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE, nameExpression,
-						MicroProfileConfigErrorCode.NO_VALUE_ASSIGNED_TO_PROPERTY, DiagnosticSeverity.Warning);
-				setDataForUnassigned(name, d);
-			}
-		}
-	}
+        if (name != null) {
+            if (name.isEmpty()) {
+                String message = MessageFormat.format(EMPTY_KEY_ERROR_MESSAGE, CONFIG_PROPERTY_ANNOTATION_NAME);
+                Diagnostic d = super.addDiagnostic(message, MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE, nameExpression,
+                        MicroProfileConfigErrorCode.EMPTY_KEY, DiagnosticSeverity.Error);
+            } else if (!hasDefaultValue && !doesPropertyHaveValue(name, getContext()) && !isPropertyIgnored(name)) {
+                String message = MessageFormat.format(NO_VALUE_ERROR_MESSAGE, name);
+                Diagnostic d = super.addDiagnostic(message, MICRO_PROFILE_CONFIG_DIAGNOSTIC_SOURCE, nameExpression,
+                        MicroProfileConfigErrorCode.NO_VALUE_ASSIGNED_TO_PROPERTY, DiagnosticSeverity.Warning);
+                setDataForUnassigned(name, d);
+            }
+        }
+    }
 
-	private boolean isPropertyIgnored(String propertyName) {
-		for (String pattern : patterns) {
-			if (pathMatcher.match(pattern, propertyName)) {
-				return true;
-			}
-		}
-		return false;
-	}
+    private boolean isPropertyIgnored(String propertyName) {
+        for (String pattern : patterns) {
+            if (pathMatcher.match(pattern, propertyName)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	private static boolean isListLike(PsiType type) {
-		if (type instanceof PsiArrayType) {
-			return true;
-		}
-		PsiType erasedType = TypeConversionUtil.erasure(type);
-		String fqn = erasedType.getCanonicalText();
-		return "java.util.List".equals(fqn) || "java.util.Set".equals(fqn);
-	}
+    private static boolean isListLike(PsiType type) {
+        if (type instanceof PsiArrayType) {
+            return true;
+        }
+        PsiType erasedType = TypeConversionUtil.erasure(type);
+        String fqn = erasedType.getCanonicalText();
+        return "java.util.List".equals(fqn) || "java.util.Set".equals(fqn);
+    }
 
 
-	private static boolean isAssignable(PsiType fieldBinding, Module javaProject, String defValue) {
-		String fqn = TypeConversionUtil.erasure(fieldBinding).getCanonicalText();
-		// handle list-like types.
-		// MicroProfile config supports arrays, `java.util.List`, and `java.util.Set` by
-		// default. See:
-		// https://download.eclipse.org/microprofile/microprofile-config-2.0/microprofile-config-spec-2.0.html#_array_converters
-		if (isListLike(fieldBinding)) {
-			if (defValue.isEmpty()) {
-				// A different error is shown in this case
-				return true;
-			}
-			String itemsTypeFqn = "java.lang.Object";
-			if (fieldBinding instanceof PsiArrayType) {
-				itemsTypeFqn = TypeConversionUtil.erasure(((PsiArrayType)fieldBinding).getComponentType()).getCanonicalText();
-			} else if (fieldBinding instanceof PsiClassType) {
-				PsiClassType collection = (PsiClassType) fieldBinding;
-				if (collection.getParameterCount() < 1) {
-					return true;
-				}
-				itemsTypeFqn = TypeConversionUtil.erasure(collection.getParameters()[0]).getCanonicalText();
-			}
-			for (String listItemValue : ARRAY_SPLITTER.split(defValue, -1)) {
-				listItemValue = listItemValue.replace("\\,", ",");
-				if (!isAssignable(itemsTypeFqn, listItemValue, javaProject)) {
-					return false;
-				}
-			}
-			return true;
-		} else {
-			// Not a list-like type
-			return isAssignable(fqn, defValue, javaProject);
-		}
-	}
+    private static boolean isAssignable(PsiType fieldBinding, Module javaProject, String defValue) {
+        String fqn = TypeConversionUtil.erasure(fieldBinding).getCanonicalText();
+        // handle list-like types.
+        // MicroProfile config supports arrays, `java.util.List`, and `java.util.Set` by
+        // default. See:
+        // https://download.eclipse.org/microprofile/microprofile-config-2.0/microprofile-config-spec-2.0.html#_array_converters
+        if (isListLike(fieldBinding)) {
+            if (defValue.isEmpty()) {
+                // A different error is shown in this case
+                return true;
+            }
+            String itemsTypeFqn = "java.lang.Object";
+            if (fieldBinding instanceof PsiArrayType) {
+                itemsTypeFqn = TypeConversionUtil.erasure(((PsiArrayType) fieldBinding).getComponentType()).getCanonicalText();
+            } else if (fieldBinding instanceof PsiClassType) {
+                PsiClassType collection = (PsiClassType) fieldBinding;
+                if (collection.getParameterCount() < 1) {
+                    return true;
+                }
+                itemsTypeFqn = TypeConversionUtil.erasure(collection.getParameters()[0]).getCanonicalText();
+            }
+            for (String listItemValue : ARRAY_SPLITTER.split(defValue, -1)) {
+                listItemValue = listItemValue.replace("\\,", ",");
+                if (!isAssignable(itemsTypeFqn, listItemValue, javaProject)) {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            // Not a list-like type
+            return isAssignable(fqn, defValue, javaProject);
+        }
+    }
 
-	private static boolean isAssignable(String typeFqn, String value, Module javaProject) {
-		try {
-			switch (typeFqn) {
-				case "boolean":
-				case "java.lang.Boolean":
-					return Boolean.valueOf(value) != null;
-				case "byte":
-				case "java.lang.Byte":
-					return Byte.valueOf(value) != null;
-				case "short":
-				case "java.lang.Short":
-					return Short.valueOf(value) != null;
-				case "int":
-				case "java.lang.Integer":
-					return Integer.valueOf(value) != null;
-				case "long":
-				case "java.lang.Long":
-					return Long.valueOf(value) != null;
-				case "float":
-				case "java.lang.Float":
-					return Float.valueOf(value) != null;
-				case "double":
-				case "java.lang.Double":
-					return Double.valueOf(value) != null;
-				case "char":
-				case "java.lang.Character":
-					if (value == null || value.length() != 1) {
-						return false;
-					}
-					return Character.valueOf(value.charAt(0)) != null;
-				case "java.lang.Class":
-					return  PsiTypeUtils.findType(javaProject, value) != null;
-				case "java.lang.String":
-					return true;
-				default:
-					return false;
-			}
-		} catch (NumberFormatException e) {
-			return false;
-		}
-	}
+    private static boolean isAssignable(String typeFqn, String value, Module javaProject) {
+        try {
+            switch (typeFqn) {
+                case "boolean":
+                case "java.lang.Boolean":
+                    return Boolean.valueOf(value) != null;
+                case "byte":
+                case "java.lang.Byte":
+                    return Byte.valueOf(value) != null;
+                case "short":
+                case "java.lang.Short":
+                    return Short.valueOf(value) != null;
+                case "int":
+                case "java.lang.Integer":
+                    return Integer.valueOf(value) != null;
+                case "long":
+                case "java.lang.Long":
+                    return Long.valueOf(value) != null;
+                case "float":
+                case "java.lang.Float":
+                    return Float.valueOf(value) != null;
+                case "double":
+                case "java.lang.Double":
+                    return Double.valueOf(value) != null;
+                case "char":
+                case "java.lang.Character":
+                    if (value == null || value.length() != 1) {
+                        return false;
+                    }
+                    return Character.valueOf(value.charAt(0)) != null;
+                case "java.lang.Class":
+                    return PsiTypeUtils.findType(javaProject, value) != null;
+                case "java.lang.String":
+                    return true;
+                default:
+                    return false;
+            }
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
 
-	private static boolean doesPropertyHaveValue(String property, JavaDiagnosticsContext context) {
-		Module javaProject = context.getJavaProject();
-		PsiMicroProfileProject mpProject = PsiMicroProfileProjectManager.getInstance(javaProject.getProject())
-				.getMicroProfileProject(javaProject);
-		return mpProject.hasProperty(property);
-	}
+    private static boolean doesPropertyHaveValue(String property, JavaDiagnosticsContext context) {
+        Module javaProject = context.getJavaProject();
+        PsiMicroProfileProject mpProject = PsiMicroProfileProjectManager.getInstance(javaProject.getProject())
+                .getMicroProfileProject(javaProject);
+        return mpProject.hasProperty(property);
+    }
 
-	public static void setDataForUnassigned(String name, Diagnostic diagnostic) {
-		JsonObject data = new JsonObject();
-		data.addProperty(DIAGNOSTIC_DATA_NAME, name);
-		diagnostic.setData(data);
-	}
+    public static void setDataForUnassigned(String name, Diagnostic diagnostic) {
+        diagnostic.setData(new PropertyNameData(name));
+    }
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/config/java/NoValueAssignedToPropertyQuickFix.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/config/java/NoValueAssignedToPropertyQuickFix.java
@@ -13,24 +13,11 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.config.java;
 
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileConfigConstants.CONFIG_PROPERTY_ANNOTATION;
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileConfigConstants.CONFIG_PROPERTY_ANNOTATION_NAME;
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileConfigConstants.DIAGNOSTIC_DATA_NAME;
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils.getAnnotation;
-import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils.getAnnotationMemberValue;
-import static org.eclipse.lsp4mp.commons.codeaction.MicroProfileCodeActionFactory.createAddToUnassignedExcludedCodeAction;
-
-import java.text.MessageFormat;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
 import com.intellij.openapi.module.Module;
 import com.intellij.psi.PsiAnnotation;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.codeStyle.CodeStyleSettingsManager;
-import org.eclipse.lsp4mp.ls.commons.CodeActionFactory;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.java.codeaction.IJavaCodeActionParticipant;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionContext;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.java.codeaction.JavaCodeActionResolveContext;
@@ -38,21 +25,23 @@ import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.project.IConfigSource;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.project.PsiMicroProfileProject;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.project.PsiMicroProfileProjectManager;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
-import org.eclipse.lsp4j.CodeAction;
-import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.TextDocumentEdit;
-import org.eclipse.lsp4j.TextDocumentItem;
-
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
-import org.eclipse.lsp4j.WorkspaceEdit;
+import com.redhat.devtools.lsp4ij.JSONUtils;
+import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4mp.commons.codeaction.CodeActionResolveData;
 import org.eclipse.lsp4mp.commons.codeaction.MicroProfileCodeActionId;
+import org.eclipse.lsp4mp.ls.commons.CodeActionFactory;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileConfigConstants.CONFIG_PROPERTY_ANNOTATION;
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileConfigConstants.CONFIG_PROPERTY_ANNOTATION_NAME;
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils.getAnnotation;
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.AnnotationUtils.getAnnotationMemberValue;
+import static org.eclipse.lsp4mp.commons.codeaction.MicroProfileCodeActionFactory.createAddToUnassignedExcludedCodeAction;
 
 /**
  * QuickFix for fixing
@@ -62,107 +51,105 @@ import org.eclipse.lsp4mp.commons.codeaction.MicroProfileCodeActionId;
  * <ul>
  * <li>Insert the proper property inside *.properties files.</li>
  * </ul>
- * 
- * @author Angelo ZERR
  *
+ * @author Angelo ZERR
  */
 public class NoValueAssignedToPropertyQuickFix implements IJavaCodeActionParticipant {
 
-	private static final String CODE_ACTION_LABEL = "Insert ''{0}'' property in ''{1}''";
+    private static final String CODE_ACTION_LABEL = "Insert ''{0}'' property in ''{1}''";
 
-	private static final String PROPERTY_NAME_KEY = "propertyName";
-	private static final String CONFIG_TEXT_DOCUMENT_URI_KEY = "uri";
+    private static final String PROPERTY_NAME_KEY = "propertyName";
+    private static final String CONFIG_TEXT_DOCUMENT_URI_KEY = "uri";
 
-	@Override
-	public String getParticipantId() {
-		return NoValueAssignedToPropertyQuickFix.class.getName();
-	}
+    @Override
+    public String getParticipantId() {
+        return NoValueAssignedToPropertyQuickFix.class.getName();
+    }
 
-	@Override
-	public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
-		List<CodeAction> codeActions = new ArrayList<>();
-		Module javaProject = context.getJavaProject();
+    @Override
+    public List<? extends CodeAction> getCodeActions(JavaCodeActionContext context, Diagnostic diagnostic) {
+        List<CodeAction> codeActions = new ArrayList<>();
+        Module javaProject = context.getJavaProject();
 
-		String lineSeparator = CodeStyleSettingsManager.getInstance(javaProject.getProject()).getMainProjectCodeStyle().
-				getLineSeparator();
-		if (lineSeparator == null) {
-			lineSeparator = System.lineSeparator();
-		}
-		String propertyName = getPropertyName(diagnostic, context);
-		String insertText = propertyName + "=" + lineSeparator;
+        String lineSeparator = CodeStyleSettingsManager.getInstance(javaProject.getProject()).getMainProjectCodeStyle().
+                getLineSeparator();
+        if (lineSeparator == null) {
+            lineSeparator = System.lineSeparator();
+        }
+        String propertyName = getPropertyName(diagnostic, context);
+        String insertText = propertyName + "=" + lineSeparator;
 
-		PsiMicroProfileProject mpProject = PsiMicroProfileProjectManager.getInstance(javaProject.getProject()).
+        PsiMicroProfileProject mpProject = PsiMicroProfileProjectManager.getInstance(javaProject.getProject()).
                 getMicroProfileProject(javaProject);
-		List<IConfigSource> configSources = mpProject.getConfigSources();
-		for (IConfigSource configSource : configSources) {
-			String uri = configSource.getSourceConfigFileURI();
-			if (uri != null) {
-				// the properties file exists
-				TextDocumentItem document = new TextDocumentItem(uri, "properties", 0, insertText);
-				CodeAction codeAction = CodeActionFactory.insert(
-						getTitle(propertyName, configSource.getConfigFileName()), MicroProfileCodeActionId.AssignValueToProperty, new Position(0, 0), insertText,
-						document, diagnostic);
-				codeActions.add(codeAction);
-			}
-		}
-		if (context.getParams().isCommandConfigurationUpdateSupported()) {
-			// Exclude validation for the given property
-			codeActions.add(createAddToUnassignedExcludedCodeAction(propertyName, diagnostic));
-		}
-		return codeActions;
-	}
+        List<IConfigSource> configSources = mpProject.getConfigSources();
+        for (IConfigSource configSource : configSources) {
+            String uri = configSource.getSourceConfigFileURI();
+            if (uri != null) {
+                // the properties file exists
+                TextDocumentItem document = new TextDocumentItem(uri, "properties", 0, insertText);
+                CodeAction codeAction = CodeActionFactory.insert(
+                        getTitle(propertyName, configSource.getConfigFileName()), MicroProfileCodeActionId.AssignValueToProperty, new Position(0, 0), insertText,
+                        document, diagnostic);
+                codeActions.add(codeAction);
+            }
+        }
+        if (context.getParams().isCommandConfigurationUpdateSupported()) {
+            // Exclude validation for the given property
+            codeActions.add(createAddToUnassignedExcludedCodeAction(propertyName, diagnostic));
+        }
+        return codeActions;
+    }
 
-	@Override
-	public CodeAction resolveCodeAction(JavaCodeActionResolveContext context) {
-		CodeAction unresolved = context.getUnresolved();
-		CodeActionResolveData data = (CodeActionResolveData) context.getUnresolved().getData();
-		String uri = (String) data.getExtendedDataEntry(CONFIG_TEXT_DOCUMENT_URI_KEY);
-		String propertyName = (String) data.getExtendedDataEntry(PROPERTY_NAME_KEY);
-		Module javaProject = context.getJavaProject();
+    @Override
+    public CodeAction resolveCodeAction(JavaCodeActionResolveContext context) {
+        CodeAction unresolved = context.getUnresolved();
+        CodeActionResolveData data = (CodeActionResolveData) context.getUnresolved().getData();
+        String uri = (String) data.getExtendedDataEntry(CONFIG_TEXT_DOCUMENT_URI_KEY);
+        String propertyName = (String) data.getExtendedDataEntry(PROPERTY_NAME_KEY);
+        Module javaProject = context.getJavaProject();
 
-		String lineSeparator = CodeStyleSettingsManager.getInstance(javaProject.getProject()).getMainProjectCodeStyle().
-				getLineSeparator();
-		if (lineSeparator == null) {
-			lineSeparator = System.lineSeparator();
-		}
-		String insertText = propertyName + "=" + lineSeparator;
-		TextDocumentEdit tde = insertTextEdit(new TextDocumentItem(uri, "properties", 0, insertText), insertText,
-				new Position(0, 0));
-		unresolved.setEdit(new WorkspaceEdit(Collections.singletonList(Either.forLeft(tde))));
-		return unresolved;
-	}
+        String lineSeparator = CodeStyleSettingsManager.getInstance(javaProject.getProject()).getMainProjectCodeStyle().
+                getLineSeparator();
+        if (lineSeparator == null) {
+            lineSeparator = System.lineSeparator();
+        }
+        String insertText = propertyName + "=" + lineSeparator;
+        TextDocumentEdit tde = insertTextEdit(new TextDocumentItem(uri, "properties", 0, insertText), insertText,
+                new Position(0, 0));
+        unresolved.setEdit(new WorkspaceEdit(Collections.singletonList(Either.forLeft(tde))));
+        return unresolved;
+    }
 
-	private static TextDocumentEdit insertTextEdit(TextDocumentItem document, String insertText, Position position) {
-		VersionedTextDocumentIdentifier documentId = new VersionedTextDocumentIdentifier(document.getUri(),
-				document.getVersion());
-		TextEdit te = new TextEdit(new Range(position, position), insertText);
-		return new TextDocumentEdit(documentId, Collections.singletonList(te));
-	}
+    private static TextDocumentEdit insertTextEdit(TextDocumentItem document, String insertText, Position position) {
+        VersionedTextDocumentIdentifier documentId = new VersionedTextDocumentIdentifier(document.getUri(),
+                document.getVersion());
+        TextEdit te = new TextEdit(new Range(position, position), insertText);
+        return new TextDocumentEdit(documentId, Collections.singletonList(te));
+    }
 
 
-	private static String getPropertyName(Diagnostic diagnostic, JavaCodeActionContext context) {
-		if (diagnostic.getData() != null) {
-			// retrieve the property name from the diagnostic data
-			JsonObject data = (JsonObject) diagnostic.getData();
-			JsonElement name = data.get(DIAGNOSTIC_DATA_NAME);
-			if (name != null) {
-				return name.getAsString();
-			}
-		}
+    private static String getPropertyName(Diagnostic diagnostic, JavaCodeActionContext context) {
+        if (diagnostic.getData() != null) {
+            // retrieve the property name from the diagnostic data
+            PropertyNameData data = JSONUtils.toModel(diagnostic.getData(), PropertyNameData.class);
+            if (data != null && data.getName() != null) {
+                return data.getName();
+            }
+        }
 
-		// retrieve the property name from the data
-		Position hoverPosition = diagnostic.getRange().getStart();
-		IPsiUtils utils = context.getUtils();
-		PsiFile typeRoot = context.getTypeRoot();
-		int offset = utils.toOffset(typeRoot, hoverPosition.getLine(), hoverPosition.getCharacter());
-		PsiElement hoverElement = typeRoot.findElementAt(offset);
+        // retrieve the property name from the data
+        Position hoverPosition = diagnostic.getRange().getStart();
+        IPsiUtils utils = context.getUtils();
+        PsiFile typeRoot = context.getTypeRoot();
+        int offset = utils.toOffset(typeRoot, hoverPosition.getLine(), hoverPosition.getCharacter());
+        PsiElement hoverElement = typeRoot.findElementAt(offset);
 
-		PsiAnnotation configPropertyAnnotation = getAnnotation(hoverElement, CONFIG_PROPERTY_ANNOTATION);
-		return getAnnotationMemberValue(configPropertyAnnotation, CONFIG_PROPERTY_ANNOTATION_NAME);
-	}
+        PsiAnnotation configPropertyAnnotation = getAnnotation(hoverElement, CONFIG_PROPERTY_ANNOTATION);
+        return getAnnotationMemberValue(configPropertyAnnotation, CONFIG_PROPERTY_ANNOTATION_NAME);
+    }
 
-	private static String getTitle(String propertyName, String configFileName) {
-		return MessageFormat.format(CODE_ACTION_LABEL, propertyName, configFileName);
-	}
+    private static String getTitle(String propertyName, String configFileName) {
+        return MessageFormat.format(CODE_ACTION_LABEL, propertyName, configFileName);
+    }
 
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/config/java/PropertyNameData.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/config/java/PropertyNameData.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.config.java;
+
+import java.util.Objects;
+
+/**
+ * Data used in the unassigned property name diagnostic:
+ *
+ * <code>@ConfigProperty("missing.property")</code>
+ */
+public class PropertyNameData {
+
+    private String name;
+
+    PropertyNameData() {
+        this(null);
+    }
+
+    public PropertyNameData(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PropertyNameData that = (PropertyNameData) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/core/command/QuteAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/core/command/QuteAction.java
@@ -14,23 +14,22 @@ import com.google.gson.JsonPrimitive;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.redhat.devtools.lsp4ij.commands.CommandExecutor;
+import com.redhat.devtools.lsp4ij.commands.LSPCommand;
 import com.redhat.devtools.lsp4ij.commands.LSPCommandAction;
 
 import java.util.List;
 
 public abstract class QuteAction extends LSPCommandAction {
 
-    protected String getURL(List<Object> arguments) {
-        String url = null;
-        if (!arguments.isEmpty()) {
-            Object arg = arguments.get(0);
-            if (arg instanceof JsonPrimitive) {
-                url = ((JsonPrimitive) arg).getAsString();
-            } else if (arg instanceof String) {
-                url = (String) arg;
-            }
+    protected String getURL(LSPCommand command) {
+        Object arg = command.getArgumentAt(0);
+        if (arg instanceof JsonPrimitive) {
+            return ((JsonPrimitive) arg).getAsString();
         }
-        return url;
+        if (arg instanceof String) {
+            return (String) arg;
+        }
+        return null;
     }
 
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/core/command/QuteGenerateTemplateAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/core/command/QuteGenerateTemplateAction.java
@@ -18,6 +18,7 @@ import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.lsp4ij.LanguageServiceAccessor;
 import com.redhat.devtools.lsp4ij.commands.CommandExecutor;
+import com.redhat.devtools.lsp4ij.commands.LSPCommand;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.ExecuteCommandParams;
@@ -41,45 +42,51 @@ public class QuteGenerateTemplateAction extends QuteAction {
             ExecuteCommandOptions provider = cap.getExecuteCommandProvider();
             return provider != null && provider.getCommands().contains(QUTE_COMMAND_GENERATE_TEMPLATE_CONTENT);
         });
-        return servers.isEmpty()?null:servers.get(0);
+        return servers.isEmpty() ? null : servers.get(0);
     }
 
-
     @Override
-    protected void commandPerformed(@NotNull Command command, @NotNull AnActionEvent e) {
+    protected void commandPerformed(@NotNull LSPCommand command, @NotNull AnActionEvent e) {
         LanguageServer server = getFirstServer(e);
         try {
             if (server != null) {
-                URI uri = getURI(command.getArguments());
+                URI uri = getURI(command);
                 ExecuteCommandParams params = new ExecuteCommandParams();
                 params.setCommand(QUTE_COMMAND_GENERATE_TEMPLATE_CONTENT);
-                params.setArguments(command.getArguments());
-                server.getWorkspaceService().executeCommand(params).thenApply(content -> {
-                    try {
-                        Path path = Path.of(uri);
-                        Files.createDirectories(path.getParent());
-                        Files.createFile(path);
-                        Files.writeString(path, content.toString());
-                        VirtualFile f = VfsUtil.findFile(path, true);
-                        if (f != null) {
-                            ApplicationManager.getApplication().invokeLater(() -> FileEditorManager.getInstance(e.getProject()).openFile(f, true));
-                        }
-                    } catch (IOException ex) {
-                        LOGGER.log(System.Logger.Level.WARNING, ex.getLocalizedMessage(), ex);
-                    }
-                    return content;
-                });
+                params.setArguments(command.getOriginalArguments());
+                server.getWorkspaceService()
+                        .executeCommand(params)
+                        .thenApply(content -> {
+                            try {
+                                Path path = Path.of(uri);
+                                Files.createDirectories(path.getParent());
+                                Files.createFile(path);
+                                Files.writeString(path, content.toString());
+                                VirtualFile f = VfsUtil.findFile(path, true);
+                                if (f != null) {
+                                    ApplicationManager.getApplication().invokeLater(() -> FileEditorManager.getInstance(e.getProject()).openFile(f, true));
+                                }
+                            } catch (IOException ex) {
+                                LOGGER.log(System.Logger.Level.WARNING, ex.getLocalizedMessage(), ex);
+                            }
+                            return content;
+                        }).exceptionally(ex -> {
+                            LOGGER.log(System.Logger.Level.WARNING, "Error while generating Qute template", ex);
+                          return ex;
+                        });
             }
         } catch (URISyntaxException ex) {
             LOGGER.log(System.Logger.Level.WARNING, ex.getLocalizedMessage(), ex);
         }
     }
 
-    private URI getURI(List<Object> arguments) throws URISyntaxException {
-        URI uri = null;
-        if (!arguments.isEmpty() && arguments.get(0) instanceof JsonObject && ((JsonObject) arguments.get(0)).has(TEMPLATE_FILE_URI)) {
-            uri = new URI(((JsonObject) arguments.get(0)).get(TEMPLATE_FILE_URI).getAsString());
+    private URI getURI(LSPCommand command) throws URISyntaxException {
+        Object arg = command.getArgumentAt(0);
+        if (arg instanceof JsonObject jsonObject) {
+            if (jsonObject.has(TEMPLATE_FILE_URI)) {
+                return new URI(jsonObject.get(TEMPLATE_FILE_URI).getAsString());
+            }
         }
-        return uri;
+        return null;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/core/command/QuteJavaDefinitionAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/core/command/QuteJavaDefinitionAction.java
@@ -18,6 +18,7 @@ import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import com.redhat.devtools.intellij.qute.psi.QuteSupportForTemplate;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.commands.LSPCommand;
 import com.redhat.qute.commons.QuteJavaDefinitionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Location;
@@ -35,8 +36,8 @@ public class QuteJavaDefinitionAction extends QuteAction {
     private static System.Logger LOGGER = System.getLogger(QuteJavaDefinitionAction.class.getName());
 
     @Override
-    protected void commandPerformed(@NotNull Command command, @NotNull AnActionEvent e) {
-        QuteJavaDefinitionParams params = getQuteJavaDefinitionParams(command.getArguments());
+    protected void commandPerformed(@NotNull LSPCommand command, @NotNull AnActionEvent e) {
+        QuteJavaDefinitionParams params = getQuteJavaDefinitionParams(command);
         if (params != null) {
             Project project = e.getProject();
             IPsiUtils utils = PsiUtilsLSImpl.getInstance(project);
@@ -53,9 +54,9 @@ public class QuteJavaDefinitionAction extends QuteAction {
         return obj.has(name) ? obj.get(name).getAsBoolean() : false;
     }
 
-    private QuteJavaDefinitionParams getQuteJavaDefinitionParams(List<Object> arguments) {
-        if (!arguments.isEmpty() && arguments.get(0) instanceof JsonObject) {
-            JsonObject obj = ((JsonObject) arguments.get(0));
+    private QuteJavaDefinitionParams getQuteJavaDefinitionParams(@NotNull LSPCommand command) {
+        Object arg = command.getArgumentAt(0);
+        if (arg instanceof JsonObject obj) {
             String templateFileUri = getString(PROJECT_URI_ATTR, obj);
             String sourceType = getString(SOURCE_TYPE_ATTR, obj);
             QuteJavaDefinitionParams params = new QuteJavaDefinitionParams(sourceType, templateFileUri);

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/core/command/QuteOpenURIAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/core/command/QuteOpenURIAction.java
@@ -13,14 +13,15 @@ package com.redhat.devtools.intellij.qute.psi.core.command;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.commands.LSPCommand;
 import org.eclipse.lsp4j.Command;
 import org.jetbrains.annotations.NotNull;
 
 public class QuteOpenURIAction extends QuteAction {
 
     @Override
-    protected void commandPerformed(@NotNull Command command, @NotNull AnActionEvent e) {
-        String url = getURL(command.getArguments());
+    protected void commandPerformed(@NotNull LSPCommand command, @NotNull AnActionEvent e) {
+        String url = getURL(command);
         Project project = e.getProject();
         if (url != null && project != null) {
             LSPIJUtils.openInEditor(url, null, project);

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/core/command/QuteUpdateConfigurationAction.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/core/command/QuteUpdateConfigurationAction.java
@@ -31,6 +31,7 @@ import com.intellij.psi.impl.FakePsiElement;
 import com.redhat.devtools.intellij.qute.psi.core.inspections.QuteGlobalInspection;
 import com.redhat.devtools.intellij.qute.psi.core.inspections.QuteUndefinedObjectInspection;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.commands.LSPCommand;
 import com.redhat.devtools.lsp4ij.commands.LSPCommandAction;
 import com.redhat.devtools.lsp4ij.inspections.AbstractDelegateInspectionWithExclusions;
 import com.redhat.devtools.lsp4ij.operations.diagnostics.SeverityMapping;
@@ -55,7 +56,7 @@ public class QuteUpdateConfigurationAction extends LSPCommandAction {
     }
 
     @Override
-    protected void commandPerformed(@NotNull Command command, @NotNull AnActionEvent e) {
+    protected void commandPerformed(@NotNull LSPCommand command, @NotNull AnActionEvent e) {
         JsonObject configUpdate = getConfigUpdate(command);
         if (configUpdate != null && e.getProject() != null) {
             String section = configUpdate.get("section").getAsString();
@@ -67,13 +68,10 @@ public class QuteUpdateConfigurationAction extends LSPCommandAction {
         }
     }
 
-    private @Nullable JsonObject getConfigUpdate(@NotNull Command command) {
-        List<Object> arguments = command.getArguments();
-        if (arguments != null && !arguments.isEmpty()) {
-            Object arg = arguments.get(0);
-            if (arg instanceof JsonObject) {
-                return (JsonObject) arg;
-            }
+    private @Nullable JsonObject getConfigUpdate(@NotNull LSPCommand command) {
+        Object arg = command.getArgumentAt(0);
+        if (arg instanceof JsonObject) {
+            return (JsonObject) arg;
         }
         return null;
     }


### PR DESCRIPTION
fix: use JSONUtils from LSP4IJ

This PR requires https://github.com/redhat-developer/lsp4ij/pull/56 to avoid having this LinkageError error problem when code action is resolved:

```
Internal error: java.lang.LinkageError: loader constraint violation: when resolving method 'com.google.gson.Gson org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler.getGson()' the class loader com.intellij.ide.plugins.cl.PluginClassLoader @47dad50f of the current class, org/eclipse/lsp4mp/commons/utils/JSONUtility, and the class loader com.intellij.ide.plugins.cl.PluginClassLoader @54c5da1d for the method's defining class, org/eclipse/lsp4j/jsonrpc/json/MessageJsonHandler, have different Class objects for the type com/google/gson/Gson used in the signature (org.eclipse.lsp4mp.commons.utils.JSONUtility is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @47dad50f, parent loader 'bootstrap'; org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @54c5da1d, parent loader 'bootstrap')

java.util.concurrent.CompletionException: java.lang.LinkageError: loader constraint violation: when resolving method 'com.google.gson.Gson org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler.getGson()' the class loader com.intellij.ide.plugins.cl.PluginClassLoader @47dad50f of the current class, org/eclipse/lsp4mp/commons/utils/JSONUtility, and the class loader com.intellij.ide.plugins.cl.PluginClassLoader @54c5da1d for the method's defining class, org/eclipse/lsp4j/jsonrpc/json/MessageJsonHandler, have different Class objects for the type com/google/gson/Gson used in the signature (org.eclipse.lsp4mp.commons.utils.JSONUtility is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @47dad50f, parent loader 'bootstrap'; org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @54c5da1d, parent loader 'bootstrap')
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:332)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:347)
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(CompletableFuture.java:708)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162)
	at com.redhat.devtools.lsp4ij.internal.PromiseToCompletableFuture.lambda$bind$0(PromiseToCompletableFuture.java:98)
	at org.jetbrains.concurrency.AsyncPromise.onError$lambda$4(AsyncPromise.kt:96)
	at org.jetbrains.concurrency.AsyncPromise$whenComplete$1.invoke(AsyncPromise.kt:114)
	at org.jetbrains.concurrency.AsyncPromise$whenComplete$1.invoke(AsyncPromise.kt:112)
	at org.jetbrains.concurrency.AsyncPromise.whenComplete$lambda$6(AsyncPromise.kt:112)
	at java.base/java.util.concurrent.CompletableFuture.uniHandle(CompletableFuture.java:934)
	at java.base/java.util.concurrent.CompletableFuture$UniHandle.tryFire(CompletableFuture.java:911)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2162)
	at org.jetbrains.concurrency.AsyncPromise.setError(AsyncPromise.kt:192)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.setError(NonBlockingReadActionImpl.java:338)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.insideReadAction(NonBlockingReadActionImpl.java:630)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$attemptComputation$4(NonBlockingReadActionImpl.java:567)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1075)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.lambda$runInReadActionWithWriteActionPriority$0(ProgressIndicatorUtils.java:73)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtilService.runActionAndCancelBeforeWrite(ProgressIndicatorUtilService.java:73)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runActionAndCancelBeforeWrite(ProgressIndicatorUtils.java:128)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.lambda$runWithWriteActionPriority$1(ProgressIndicatorUtils.java:111)
	at com.intellij.openapi.progress.ProgressManager.lambda$runProcess$0(ProgressManager.java:73)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$1(CoreProgressManager.java:192)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$12(CoreProgressManager.java:610)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:685)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:641)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:609)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:78)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:179)
	at com.intellij.openapi.progress.ProgressManager.runProcess(ProgressManager.java:73)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runWithWriteActionPriority(ProgressIndicatorUtils.java:108)
	at com.intellij.openapi.progress.util.ProgressIndicatorUtils.runInReadActionWithWriteActionPriority(ProgressIndicatorUtils.java:73)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.attemptComputation(NonBlockingReadActionImpl.java:567)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$transferToBgThread$1(NonBlockingReadActionImpl.java:466)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.lambda$transferToBgThread$2(NonBlockingReadActionImpl.java:481)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:702)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:699)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:699)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.LinkageError: loader constraint violation: when resolving method 'com.google.gson.Gson org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler.getGson()' the class loader com.intellij.ide.plugins.cl.PluginClassLoader @47dad50f of the current class, org/eclipse/lsp4mp/commons/utils/JSONUtility, and the class loader com.intellij.ide.plugins.cl.PluginClassLoader @54c5da1d for the method's defining class, org/eclipse/lsp4j/jsonrpc/json/MessageJsonHandler, have different Class objects for the type com/google/gson/Gson used in the signature (org.eclipse.lsp4mp.commons.utils.JSONUtility is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @47dad50f, parent loader 'bootstrap'; org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler is in unnamed module of loader com.intellij.ide.plugins.cl.PluginClassLoader @54c5da1d, parent loader 'bootstrap')
	at org.eclipse.lsp4mp.commons.utils.JSONUtility.<clinit>(JSONUtility.java:33)
	at com.redhat.devtools.intellij.quarkus.lsp.QuarkusLanguageClient.lambda$resolveCodeAction$17(QuarkusLanguageClient.java:253)
	at com.redhat.devtools.lsp4ij.internal.PromiseToCompletableFuture.lambda$nonBlockingReadActionPromise$2(PromiseToCompletableFuture.java:137)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$OTelMonitor.callWrapped(NonBlockingReadActionImpl.java:840)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$OTelMonitor$MonitoredComputation.call(NonBlockingReadActionImpl.java:872)
	at com.intellij.openapi.application.impl.NonBlockingReadActionImpl$Submission.insideReadAction(NonBlockingReadActionImpl.java:604)
	... 27 more

```
