### PR TITLE
build: replace remark with flexmark

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,9 +73,11 @@ sourceSets {
 
 dependencies {
     implementation("org.zeroturnaround:zt-zip:1.14")
-    implementation("com.kotcrab.remark:remark:1.2.0") //FIXME use lsp4ij's flexmark instead
-    implementation("org.jsoup:jsoup:1.14.2") //FIXME use lsp4ij's jsoup instead
-    implementation("com.google.code.gson:gson:2.10.1")
+    implementation("org.jsoup:jsoup:1.17.1")
+    implementation("com.vladsch.flexmark:flexmark-html2md-converter:0.64.8") {
+        exclude(group="com.vladsch.flexmark", module= "flexmark-jira-converter")
+    }
+    implementation("com.google.code.gson:gson:2.10.1") //Need to ensure we don't get telemetry's old gson version
     implementation("io.quarkus:quarkus-core:$quarkusVersion") {
         isTransitive = false
     }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/core/ls/PsiUtilsLSImpl.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/core/ls/PsiUtilsLSImpl.java
@@ -118,7 +118,7 @@ public class PsiUtilsLSImpl implements IPsiUtils {
 
     @Override
     public String getJavadoc(PsiMember method, com.redhat.qute.commons.DocumentFormat documentFormat) {
-        boolean markdown = DocumentFormat.Markdown.equals(documentFormat);
+        boolean markdown = DocumentFormat.Markdown.name().toLowerCase().equals(documentFormat.name().toLowerCase());
         Reader reader = markdown ? JavadocContentAccess.getMarkdownContentReader(method)
                 : JavadocContentAccess.getPlainTextContentReader(method);
         return reader != null ? toString(reader) : null;

--- a/src/main/java/com/redhat/microprofile/psi/internal/quarkus/kubernetes/properties/QuarkusKubernetesProvider.java
+++ b/src/main/java/com/redhat/microprofile/psi/internal/quarkus/kubernetes/properties/QuarkusKubernetesProvider.java
@@ -89,10 +89,10 @@ public class QuarkusKubernetesProvider extends AbstractTypeDeclarationProperties
 				// see
 				// https://github.com/quarkusio/quarkus/blob/44e5e2e3a642d1fa7af9ddea44b6ff8d37e862b8/extensions/kubernetes/deployment/src/main/java/io/quarkus/kubernetes/deployment/KubernetesProcessor.java#L94
 				super.addItemMetadata(collector, "kubernetes.deployment.target", "java.lang.String", //
-						"To enable the generation of OpenShift resources, you need to include OpenShift in the target platforms: `kubernetes.deployment.target=openshift`."
-								+ System.lineSeparator()
-								+ "If you need to generate resources for both platforms (vanilla Kubernetes and OpenShift), then you need to include both (coma separated)."
-								+ System.lineSeparator() + "`kubernetes.deployment.target=kubernetes, openshift`.",
+                        """
+                        To enable the generation of OpenShift resources, you need to include OpenShift in the target platforms: `kubernetes.deployment.target=openshift`.
+                        If you need to generate resources for both platforms (vanilla Kubernetes and OpenShift), then you need to include both (comma-separated).
+                        `kubernetes.deployment.target=kubernetes, openshift`.""",
 						null, null, null, KUBERNETES_PREFIX, null, true);
 				// kubernetes.registry
 				// see

--- a/src/test/java/com/redhat/devtools/intellij/qute/psi/template/TemplateGetJavadocTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/qute/psi/template/TemplateGetJavadocTest.java
@@ -41,7 +41,7 @@ public class TemplateGetJavadocTest extends QuteMavenModuleImportingTestCase {
 				DocumentFormat.Markdown);
 
 		String actual = QuteSupportForTemplate.getInstance().getJavadoc(params, getJDTUtils(), new EmptyProgressIndicator());
-		String expected = " The name of the item ";
+		String expected = "The name of the item";
 		assertEquals(expected, actual);
 	}
 	
@@ -57,9 +57,11 @@ public class TemplateGetJavadocTest extends QuteMavenModuleImportingTestCase {
 				DocumentFormat.Markdown);
 
 		String actual = QuteSupportForTemplate.getInstance().getJavadoc(params, getJDTUtils(), new EmptyProgressIndicator());
-		String expected = " Returns the derived items. \n" +
-				" * Returns:\n" +
-				"   - the derived items";
+		String expected = """
+				Returns the derived items.
+				
+				* **Returns:**
+				  * the derived items""";
 		assertEquals(expected, actual);
 	}
 	

--- a/src/test/java/com/redhat/microprofile/psi/quarkus/QuarkusKubernetesTest.java
+++ b/src/test/java/com/redhat/microprofile/psi/quarkus/QuarkusKubernetesTest.java
@@ -37,15 +37,18 @@ public class QuarkusKubernetesTest extends QuarkusMavenModuleImportingTestCase {
 
                 // io.dekorate.kubernetes.annotation.KubernetesApplication
                 p(null, "kubernetes.name", "java.lang.String",
-                        "The name of the application. This value will be used for naming Kubernetes resources like: - Deployment - Service and so on ... If no value is specified it will attempt to determine the name using the following rules: If its a maven/gradle project use the artifact id. Else if its a bazel project use the name. Else if the system property app.name is present it will be used. Else find the project root folder and use its name (root folder detection is done by moving to the parent folder until .git is found)."
-                                + System.lineSeparator() + "" + System.lineSeparator() + " *  **Returns:**" + System.lineSeparator()
-                                + "    " + System.lineSeparator() + "     *  The specified application name.",
+                        """
+                                The name of the application. This value will be used for naming Kubernetes resources like: - Deployment - Service and so on ... If no value is specified it will attempt to determine the name using the following rules: If its a maven/gradle project use the artifact id. Else if its a bazel project use the name. Else if the system property app.name is present it will be used. Else find the project root folder and use its name (root folder detection is done by moving to the parent folder until .git is found).
+
+                                * **Returns:**
+                                  * The specified application name.""",
                         true, "io.dekorate.kubernetes.annotation.KubernetesApplication", null, "name()Ljava/lang/String;", 0, null),
 
-                p(null, "kubernetes.readiness-probe.initial-delay-seconds", "int", "The amount of time to wait in seconds before starting to probe." + //
-                                System.lineSeparator() + "" + System.lineSeparator() + //
-                                " *  **Returns:**" + System.lineSeparator() + //
-                                "    " + System.lineSeparator() + "     *  The initial delay.",
+                p(null, "kubernetes.readiness-probe.initial-delay-seconds", "int", """
+                                The amount of time to wait in seconds before starting to probe.
+
+                                * **Returns:**
+                                  * The initial delay.""",
                         true, "io.dekorate.kubernetes.annotation.Probe", null, "initialDelaySeconds()I", 0, "0"),
 
                 p(null, "kubernetes.annotations[*].key", "java.lang.String", null, true,
@@ -56,10 +59,10 @@ public class QuarkusKubernetesTest extends QuarkusMavenModuleImportingTestCase {
                         "protocol()Lio/dekorate/kubernetes/annotation/Protocol;", 0, "TCP"),
 
                 p(null, "kubernetes.deployment.target", "java.lang.String",
-                        "To enable the generation of OpenShift resources, you need to include OpenShift in the target platforms: `kubernetes.deployment.target=openshift`."
-                                + System.lineSeparator() + ""
-                                + "If you need to generate resources for both platforms (vanilla Kubernetes and OpenShift), then you need to include both (coma separated)."
-                                + System.lineSeparator() + "" + "`kubernetes.deployment.target=kubernetes, openshift`.",
+                        """
+                                To enable the generation of OpenShift resources, you need to include OpenShift in the target platforms: `kubernetes.deployment.target=openshift`.
+                                If you need to generate resources for both platforms (vanilla Kubernetes and OpenShift), then you need to include both (comma-separated).
+                                `kubernetes.deployment.target=kubernetes, openshift`.""",
                         true, null, null, null, 0, "kubernetes"),
                 p(null, "kubernetes.registry", "java.lang.String", "Specify the docker registry.", true, null, null, null, 0,
                         null));
@@ -82,18 +85,20 @@ public class QuarkusKubernetesTest extends QuarkusMavenModuleImportingTestCase {
         MicroProfileProjectInfo info = PropertiesManager.getInstance().getMicroProfileProjectInfo(module, MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, ClasspathKind.SRC, PsiUtilsLSImpl.getInstance(myProject), DocumentFormat.Markdown, new EmptyProgressIndicator());
 
         assertProperties(info,
-
                 // io.dekorate.openshift.annotation.OpenshiftApplication
                 p(null, "openshift.name", "java.lang.String",
-                        "The name of the application. This value will be used for naming Kubernetes resources like: - Deployment - Service and so on ... If no value is specified it will attempt to determine the name using the following rules: If its a maven/gradle project use the artifact id. Else if its a bazel project use the name. Else if the system property app.name is present it will be used. Else find the project root folder and use its name (root folder detection is done by moving to the parent folder until .git is found)."
-                                + System.lineSeparator() + "" + System.lineSeparator() + " *  **Returns:**" + System.lineSeparator()
-                                + "    " + System.lineSeparator() + "     *  The specified application name.",
+                        """
+                                The name of the application. This value will be used for naming Kubernetes resources like: - Deployment - Service and so on ... If no value is specified it will attempt to determine the name using the following rules: If its a maven/gradle project use the artifact id. Else if its a bazel project use the name. Else if the system property app.name is present it will be used. Else find the project root folder and use its name (root folder detection is done by moving to the parent folder until .git is found).
+
+                                * **Returns:**
+                                  * The specified application name.""",
                         true, "io.dekorate.openshift.annotation.OpenshiftApplication", null, "name()Ljava/lang/String;", 0, null),
 
-                p(null, "openshift.readiness-probe.initial-delay-seconds", "int", "The amount of time to wait in seconds before starting to probe." + //
-                                System.lineSeparator() + "" + System.lineSeparator() + //
-                                " *  **Returns:**" + System.lineSeparator() + //
-                                "    " + System.lineSeparator() + "     *  The initial delay.", true,
+                p(null, "openshift.readiness-probe.initial-delay-seconds", "int", """
+                                The amount of time to wait in seconds before starting to probe.
+
+                                * **Returns:**
+                                  * The initial delay.""", true,
                         "io.dekorate.kubernetes.annotation.Probe", null, "initialDelaySeconds()I", 0, "0"),
 
                 p(null, "openshift.annotations[*].key", "java.lang.String", null, true,
@@ -109,7 +114,6 @@ public class QuarkusKubernetesTest extends QuarkusMavenModuleImportingTestCase {
         assertPropertiesDuplicate(info);
 
         assertHints(info,
-
                 h("io.dekorate.kubernetes.annotation.Protocol", null, true, "io.dekorate.kubernetes.annotation.Protocol",
                         vh("TCP", null, null), //
                         vh("UDP", null, null)));
@@ -124,28 +128,27 @@ public class QuarkusKubernetesTest extends QuarkusMavenModuleImportingTestCase {
         MicroProfileProjectInfo info = PropertiesManager.getInstance().getMicroProfileProjectInfo(module, MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, ClasspathKind.SRC, PsiUtilsLSImpl.getInstance(myProject), DocumentFormat.Markdown, new EmptyProgressIndicator());
 
         assertProperties(info,
-
                 // io.dekorate.s2i.annotation.S2iBuild
-                p(null, "s2i.docker-file", "java.lang.String", "The relative path of the Dockerfile, from the module root." + //
-                                System.lineSeparator() + "" + System.lineSeparator() + //
-                                " *  **Returns:**" + //
-                                System.lineSeparator() + //
-                                "    " + //
-                                System.lineSeparator() + //
-                                "     *  The relative path.", true, "io.dekorate.s2i.annotation.S2iBuild", null,
+                p(null, "s2i.docker-file", "java.lang.String", """
+                                The relative path of the Dockerfile, from the module root.
+
+                                * **Returns:**
+                                  * The relative path.""", true, "io.dekorate.s2i.annotation.S2iBuild", null,
                         "dockerFile()Ljava/lang/String;", 0, "Dockerfile"),
 
                 p(null, "s2i.group", "java.lang.String",
-                        "The group of the application. This value will be use as image user."
-                                + System.lineSeparator() + "" + System.lineSeparator() + " *  **Returns:**" + System.lineSeparator()
-                                + "    " + System.lineSeparator() + "     *  The specified group name.",
+                        """
+                                The group of the application. This value will be use as image user.
+
+                                * **Returns:**
+                                  * The specified group name.""",
                         true, "io.dekorate.s2i.annotation.S2iBuild", null, "group()Ljava/lang/String;", 0,
                         null),
 
                 p("quarkus-container-image-s2i", "quarkus.s2i.jar-directory", "java.lang.String",
-                        "The directory where the jar is added during the assemble phase." + //
-                                "\n" + //
-                                "This is dependent on the S2I image and should be supplied if a non default image is used.",
+                        """
+                                The directory where the jar is added during the assemble phase.
+                                This is dependent on the S2I image and should be supplied if a non default image is used.""",
                         true, "io.quarkus.container.image.s2i.deployment.S2iConfig", "jarDirectory", null, 1,
                         "/deployments/"));
 
@@ -159,17 +162,15 @@ public class QuarkusKubernetesTest extends QuarkusMavenModuleImportingTestCase {
     public void testDocker() throws Exception {
         Module module = loadMavenProject(QuarkusMavenProjectName.kubernetes, true);
         MicroProfileProjectInfo info = PropertiesManager.getInstance().getMicroProfileProjectInfo(module, MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES, ClasspathKind.SRC, PsiUtilsLSImpl.getInstance(myProject), DocumentFormat.Markdown, new EmptyProgressIndicator());
+        String description = """
+                            The relative path of the Dockerfile, from the module root.
 
+                            * **Returns:**
+                              * The relative path.""";
         assertProperties(info,
 
                 // io.dekorate.docker.annotation.DockerBuild
-                p(null, "docker.docker-file", "java.lang.String", "The relative path of the Dockerfile, from the module root." + //
-                                System.lineSeparator() + "" + System.lineSeparator() + //
-                                " *  **Returns:**" + //
-                                System.lineSeparator() + //
-                                "    " + //
-                                System.lineSeparator() + //
-                                "     *  The relative path.", true, "io.dekorate.docker.annotation.DockerBuild", null,
+                p(null, "docker.docker-file", "java.lang.String", description, true, "io.dekorate.docker.annotation.DockerBuild", null,
                         "dockerFile()Ljava/lang/String;", 0, "Dockerfile"));
 
         assertPropertiesDuplicate(info);


### PR DESCRIPTION
Replaces obsolete, unmaintained, unsecure remark with flexmark.

Fixes an issue with documentation always being returned as plaintext instead of markdown.

Works best with https://github.com/redhat-developer/lsp4ij/pull/59