### PR TITLE
fix: prevent IJ from reporting an error when config file is deleted

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/project/PsiMicroProfileProject.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/project/PsiMicroProfileProject.java
@@ -16,6 +16,7 @@ import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.core.project.ConfigSourcePropertiesProvider;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import org.eclipse.lsp4mp.commons.utils.ConfigSourcePropertiesProviderUtils;
 import org.eclipse.lsp4mp.commons.utils.IConfigSourcePropertiesProvider;
 import org.eclipse.lsp4mp.commons.utils.PropertyValueExpander;
@@ -195,7 +196,7 @@ public class PsiMicroProfileProject {
         if (existingConfigSource != null) {
             // The config source file exists, update / delete it from the cache
             boolean updated = ReadAction.compute(() -> {
-                PsiFile psiFile = PsiManager.getInstance(javaProject.getProject()).findFile(file);
+                PsiFile psiFile = LSPIJUtils.getPsiFile(file, javaProject.getProject());
                 if (psiFile != null) {
                     // The config source file has been updated, reload it
                     existingConfigSource.reload(psiFile);


### PR DESCRIPTION
I've seen this once after reopening IJ after deleting a quarkus config file:

```
java.lang.Throwable: Invalid file: file:///Users/fbricon/Dev/projects/intellij-quarkus/projects/lsp4mp/projects/maven/config-hover/src/main/resources/application-foo.properties (invalid)
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:202)
	at com.intellij.psi.impl.file.impl.FileManagerImpl.findFile(FileManagerImpl.java:357)
	at com.intellij.psi.impl.PsiManagerImpl.findFile(PsiManagerImpl.java:156)
	at com.redhat.devtools.intellij.lsp4mp4ij.psi.core.project.PsiMicroProfileProject.lambda$evictConfigSourcesCache$2(PsiMicroProfileProject.java:198)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:891)
	at com.intellij.openapi.application.ReadAction.compute(ReadAction.java:69)
	at com.redhat.devtools.intellij.lsp4mp4ij.psi.core.project.PsiMicroProfileProject.evictConfigSourcesCache(PsiMicroProfileProject.java:197)
	at com.redhat.devtools.intellij.lsp4mp4ij.psi.core.project.PsiMicroProfileProjectManager$MicroProfileProjectListener.sourceFilesChanged(PsiMicroProfileProjectManager.java:66)
	at com.intellij.util.messages.impl.MessageBusImplKt.invokeMethod(MessageBusImpl.kt:680)
	at com.intellij.util.messages.impl.MessageBusImplKt.invokeListener(MessageBusImpl.kt:640)
	at com.intellij.util.messages.impl.MessageBusImplKt.deliverMessage(MessageBusImpl.kt:415)
	at com.intellij.util.messages.impl.MessageBusImplKt.pumpWaiting(MessageBusImpl.kt:394)
	at com.intellij.util.messages.impl.MessageBusImplKt.access$pumpWaiting(MessageBusImpl.kt:1)
	at com.intellij.util.messages.impl.MessagePublisher.invoke(MessageBusImpl.kt:454)
	at jdk.proxy8/jdk.proxy8.$Proxy219.sourceFilesChanged(Unknown Source)
	at com.redhat.devtools.intellij.lsp4mp4ij.classpath.ClasspathResourceChangedNotifier.notifyChanges(ClasspathResourceChangedNotifier.java:110)
	at com.redhat.devtools.intellij.lsp4mp4ij.classpath.ClasspathResourceChangedNotifier$1.run(ClasspathResourceChangedNotifier.java:88)
	at java.base/java.util.TimerThread.mainLoop(Timer.java:566)
	at java.base/java.util.TimerThread.run(Timer.java:516)
```

I couldn't reproduce but the fix basically checks if the file is valid before calling PsiManager.findFile (which does the same check but then logs the error)