### PR TITLE
fix: use LSP4MP 0.12.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ platformPlugins=com.intellij.java, maven, gradle-java, properties, yaml,  com.re
 gradleVersion=8.6
 channel=nightly
 quarkusVersion=3.1.2.Final
-lsp4mpVersion=0.10.0
+lsp4mpVersion=0.12.0-SNAPSHOT
 quarkusLsVersion=0.17.0
 quteLsVersion=0.17.0
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib


### PR DESCRIPTION
fix: use LSP4MP 0.12.0-SNAPSHOT

We need this snapshot to embed the PR https://github.com/eclipse/lsp4mp/pull/444 which fixes problem of some loose of codelens / diagnostics when the LS is starting and the Java editor is opened (when IJ is starting)