### PR TITLE
fix: allow inject: with constructor class which have arguments

### DIFF
--- a/projects/qute/projects/maven/quarkus3/src/main/java/org/acme/Bean3.java
+++ b/projects/qute/projects/maven/quarkus3/src/main/java/org/acme/Bean3.java
@@ -1,0 +1,9 @@
+package org.acme;
+
+public class Bean3 {
+
+    // Quarkus can inject Bean1 in the constructor without declaring the bean1 parameter with @Inject
+    public Bean3(Bean1 bean1) {
+
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/utils/CDIUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/utils/CDIUtils.java
@@ -79,7 +79,10 @@ public class CDIUtils {
 					&& !type.getModifierList().hasExplicitModifier(PsiModifier.ABSTRACT)
 					&& !AnnotationUtils.hasAnnotation(javaElement, JAVAX_DECORATOR_ANNOTATION, JAKARTA_DECORATOR_ANNOTATION)
 					&& !AnnotationUtils.hasAnnotation(javaElement, JAVAX_INJECT_VETOED_ANNOTATION, JAKARTA_INJECT_VETOED_ANNOTATION)
-					&& PsiTypeUtils.isClass(type) && hasNoArgConstructor(type));
+					&& PsiTypeUtils.isClass(type)
+					// In Quarkus context, all arguments are injected
+					// See https://github.com/redhat-developer/vscode-quarkus/issues/708
+					/* && hasNoArgConstructor(type)*/  );
 		} catch (Exception e) {
 			return false;
 		}

--- a/src/test/java/com/redhat/devtools/intellij/qute/psi/utils/CDIUtilsTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/qute/psi/utils/CDIUtilsTest.java
@@ -90,6 +90,10 @@ public class CDIUtilsTest extends QuteMavenModuleImportingTestCase  {
 		PsiClass bean1 = PsiTypeUtils.findType(javaProject, "org.acme.Bean1");
 		// Empty class is a bean
 		assertTrue(CDIUtils.isValidBean(bean1));
+
+		PsiClass bean3 = PsiTypeUtils.findType(javaProject, "org.acme.Bean3");
+		// Class with constructor is a bean
+		assertTrue(CDIUtils.isValidBean(bean3));
 	}
 
 }


### PR DESCRIPTION
Open https://github.com/ia3andy/one-two-three-quarkus/blob/main/dashboard/src/main/resources/templates/main.html

You will see a false positive error with `inject:csrf`:

![image](https://github.com/redhat-developer/intellij-quarkus/assets/1932211/2bbe2850-ef83-47f3-bf4d-b608cc218723)

`inject:csrf` comes from https://github.com/quarkusio/quarkus/blob/e46f2ec5588858525634e42fa1c6146162ade461/extensions/resteasy-reactive/rest-csrf/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfTokenParameterProvider.java#L13

This class is flagged because it has constructor arguments https://github.com/quarkusio/quarkus/blob/e46f2ec5588858525634e42fa1c6146162ade461/extensions/resteasy-reactive/rest-csrf/runtime/src/main/java/io/quarkus/csrf/reactive/runtime/CsrfTokenParameterProvider.java#L27

Quarkus manages this arguments injection, so the  `inject:csrf` must be valid.

This PR fix the issue:
 
 *   `inject:csrf` doesn't report error
 *   completion for  `inject:csrf` should work now:

![image](https://github.com/redhat-developer/intellij-quarkus/assets/1932211/1850a0a3-bc8a-4579-9f63-3509781dcae6)


//cc @ia3andy 


