### PR TITLE
fix: relax @channel conditions for completion/validation

### DIFF
--- a/projects/lsp4mp/projects/maven/microprofile-reactive-messaging/src/main/java/org/acme/kafka/Quote.java
+++ b/projects/lsp4mp/projects/maven/microprofile-reactive-messaging/src/main/java/org/acme/kafka/Quote.java
@@ -1,0 +1,5 @@
+package org.acme.kafka;
+
+public class Quote {
+
+}

--- a/projects/lsp4mp/projects/maven/microprofile-reactive-messaging/src/main/java/org/acme/kafka/QuoteResource.java
+++ b/projects/lsp4mp/projects/maven/microprofile-reactive-messaging/src/main/java/org/acme/kafka/QuoteResource.java
@@ -1,0 +1,11 @@
+package org.acme.kafka;
+
+import io.smallrye.mutiny.Multi;
+import org.eclipse.microprofile.reactive.messaging.Channel;
+
+public class QuoteResource {
+
+	@Channel("quotes")
+    Multi<Quote> quotes;
+
+}

--- a/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/reactivemessaging/properties/MicroProfileReactiveMessagingTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/reactivemessaging/properties/MicroProfileReactiveMessagingTest.java
@@ -73,7 +73,12 @@ public class MicroProfileReactiveMessagingTest extends LSP4MPMavenModuleImportin
                 // mp.messaging.incoming.${connector-name}
                 p(null, "mp.messaging.incoming.${smallrye-kafka}.bootstrap.servers", "java.lang.String",
                         "A comma-separated list of host:port to use for establishing the initial connection to the Kafka cluster.",
-                        true, "io.smallrye.reactive.messaging.kafka.KafkaConnector", null, null, 0, "localhost:9092") //
+                        true, "io.smallrye.reactive.messaging.kafka.KafkaConnector", null, null, 0, "localhost:9092"),
+
+                // mp.messaging.outgoing.quotes.connector
+                p(null, "mp.messaging.outgoing.quotes.connector",
+                        "org.eclipse.microprofile.reactive.messaging.spi.Connector", null, false,
+                        "org.acme.kafka.QuoteResource", "quotes", null, 0, null)
         );
 
         assertPropertiesDuplicate(infoFromClasspath);


### PR DESCRIPTION
First pass at fixing the [Unrecognized property mp.messaging.* when Channel annotation is used along with Multi](https://github.com/redhat-developer/vscode-quarkus/issues/750) issue opened in VS Code Quarkus