### PR TITLE
feat: Qute: Cannot locate hyphenated template name

### DIFF
--- a/projects/qute/projects/maven/qute-record/src/main/java/org/acme/sample/ItemResource.java
+++ b/projects/qute/projects/maven/qute-record/src/main/java/org/acme/sample/ItemResource.java
@@ -1,0 +1,36 @@
+package org.acme.sample;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+
+import io.quarkus.qute.CheckedTemplate;
+import io.quarkus.qute.TemplateExtension;
+import io.quarkus.qute.TemplateInstance;
+
+@Path("items")
+public class ItemResource {
+
+	@CheckedTemplate(defaultName=CheckedTemplate.ELEMENT_NAME)
+	static class Templates {
+		static native TemplateInstance HelloWorld(String name);
+
+	}
+
+	@CheckedTemplate(defaultName=CheckedTemplate.HYPHENATED_ELEMENT_NAME)
+	static class Templates2 {
+		static native TemplateInstance HelloWorld(String name);
+
+	}
+
+	@CheckedTemplate(defaultName=CheckedTemplate.UNDERSCORED_ELEMENT_NAME)
+	static class Templates3 {
+		static native TemplateInstance HelloWorld(String name);
+	}
+
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/QuteJavaConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/QuteJavaConstants.java
@@ -52,7 +52,10 @@ public class QuteJavaConstants {
 
     public static final String CHECKED_TEMPLATE_ANNOTATION_IGNORE_FRAGMENTS = "ignoreFragments";
     public static final String CHECKED_TEMPLATE_ANNOTATION_BASE_PATH = "basePath";
-
+    public static final String CHECKED_TEMPLATE_ANNOTATION_DEFAULT_NAME = "defaultName";
+    public static final String CHECKED_TEMPLATE_ANNOTATION_DEFAULT_NAME_HYPHENATED_ELEMENT_NAME = "<<hyphenated element name>>";
+    public static final String CHECKED_TEMPLATE_ANNOTATION_DEFAULT_NAME_UNDERSCORED_ELEMENT_NAME = "<<underscored element name>>";
+    
     // @TemplateExtension
 
     public static final String TEMPLATE_EXTENSION_ANNOTATION = "io.quarkus.qute.TemplateExtension";

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/template/datamodel/TemplateFieldSupport.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/template/datamodel/TemplateFieldSupport.java
@@ -37,6 +37,7 @@ import com.redhat.devtools.intellij.qute.psi.template.datamodel.AbstractFieldDec
 import com.redhat.devtools.intellij.qute.psi.template.datamodel.SearchContext;
 import com.redhat.devtools.intellij.qute.psi.utils.AnnotationUtils;
 
+import com.redhat.devtools.intellij.qute.psi.utils.TemplateNameStrategy;
 import com.redhat.qute.commons.datamodel.DataModelParameter;
 import com.redhat.qute.commons.datamodel.DataModelTemplate;
 
@@ -106,7 +107,10 @@ public class TemplateFieldSupport extends AbstractFieldDeclarationTypeReferenceD
     }
 
     private static void collectDataModelTemplateForTemplateField(PsiField field,
-                                                                 List<DataModelTemplate<DataModelParameter>> templates, String relativeTemplateBaseDir, String location, ProgressIndicator monitor) {
+                                                                 List<DataModelTemplate<DataModelParameter>> templates,
+                                                                 String relativeTemplateBaseDir,
+                                                                 String location,
+                                                                 ProgressIndicator monitor) {
         DataModelTemplate<DataModelParameter> template = createTemplateDataModel(field, relativeTemplateBaseDir, location, monitor);
         templates.add(template);
     }
@@ -117,7 +121,7 @@ public class TemplateFieldSupport extends AbstractFieldDeclarationTypeReferenceD
         String location = locationFromConstructorParameter != null ? locationFromConstructorParameter : getLocation(field);
         String fieldName = field.getName();
         // src/main/resources/templates/${methodName}.qute.html
-        String templateUri = getTemplatePath(relativeTemplateBaseDir, null, null, location != null ? location : fieldName, true).getTemplateUri();
+        String templateUri = getTemplatePath(relativeTemplateBaseDir, null, null, location != null ? location : fieldName, true, TemplateNameStrategy.ELEMENT_NAME).getTemplateUri();
 
         // Create template data model with:
         // - template uri : Qute template file which must be bind with data model.

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/template/datamodel/TemplateRecordsSupport.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/template/datamodel/TemplateRecordsSupport.java
@@ -18,6 +18,7 @@ import com.redhat.devtools.intellij.qute.psi.internal.template.TemplateDataSuppo
 import com.redhat.devtools.intellij.qute.psi.template.datamodel.AbstractInterfaceImplementationDataModelProvider;
 import com.redhat.devtools.intellij.qute.psi.template.datamodel.SearchContext;
 import com.redhat.devtools.intellij.qute.psi.utils.PsiTypeUtils;
+import com.redhat.devtools.intellij.qute.psi.utils.TemplateNameStrategy;
 import com.redhat.qute.commons.datamodel.DataModelParameter;
 import com.redhat.qute.commons.datamodel.DataModelTemplate;
 
@@ -81,7 +82,7 @@ public class TemplateRecordsSupport extends AbstractInterfaceImplementationDataM
 
         String recordName = type.getName();
         // src/main/resources/templates/${recordName}.qute.html
-        String templateUri = getTemplatePath(relativeTemplateBaseDir, null, null, recordName, true).getTemplateUri();
+        String templateUri = getTemplatePath(relativeTemplateBaseDir, null, null, recordName, true, TemplateNameStrategy.ELEMENT_NAME).getTemplateUri();
 
         // Create template data model with:
         // - template uri : Qute template file which must be bind with data model.

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/utils/TemplateNameStrategy.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/utils/TemplateNameStrategy.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+* Copyright (c) 2022 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.devtools.intellij.qute.psi.utils;
+
+/**
+ * Qute template name strategy managed with {@link CheckedTemplate#defaultName}/
+ */
+public enum TemplateNameStrategy {
+
+	ELEMENT_NAME, //
+	HYPHENATED_ELEMENT_NAME, //
+	UNDERSCORED_ELEMENT_NAME
+}

--- a/src/test/java/com/redhat/devtools/intellij/qute/psi/java/MavenJavaCodeLensTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/qute/psi/java/MavenJavaCodeLensTest.java
@@ -374,6 +374,38 @@ public class MavenJavaCodeLensTest extends QuteMavenModuleImportingTestCase {
                         "qute.command.generate.template.file", Arrays.asList(bonjourFileUri)));
     }
 
+    @Test
+    public void testCheckedTemplateWithDefaultName() throws Exception {
+        // @CheckedTemplate(defaultName=CheckedTemplate.HYPHENATED_ELEMENT_NAME)
+        // static class Templates {
+        // static native TemplateInstance HelloWorld(String name);
+
+        var module = loadMavenProject(QuteMavenProjectName.qute_record);
+
+        QuteJavaCodeLensParams params = new QuteJavaCodeLensParams();
+        String javaFileUri = LSPIJUtils.toUri(module).resolve("src/main/java/org/acme/sample/ItemResource.java").toASCIIString();
+        params.setUri(javaFileUri);
+
+        List<? extends CodeLens> lenses = QuteSupportForJava.getInstance().codeLens(params, PsiUtilsLSImpl.getInstance(myProject),
+                new EmptyProgressIndicator());
+        assertEquals(3, lenses.size());
+
+        String helloFileUri = LSPIJUtils.toUri(module).resolve("src/main/resources/templates/ItemResource/HelloWorld.html").toASCIIString();
+        String hello2FileUri = LSPIJUtils.toUri(module).resolve("src/main/resources/templates/ItemResource/hello-world.html").toASCIIString();
+        String hello3FileUri = LSPIJUtils.toUri(module).resolve("src/main/resources/templates/ItemResource/hello_world.html").toASCIIString();
+
+        assertCodeLens(lenses, //
+                cl(r(19, 2, 19, 57), //
+                        "Create `src/main/resources/templates/ItemResource/HelloWorld.html`", //
+                        "qute.command.generate.template.file", Arrays.asList(helloFileUri)), //
+                cl(r(25, 2, 25, 57), //
+                        "Create `src/main/resources/templates/ItemResource/hello-world.html`", //
+                        "qute.command.generate.template.file", Arrays.asList(hello2FileUri)), //
+                cl(r(31, 2, 31, 57), //
+                        "Create `src/main/resources/templates/ItemResource/hello_world.html`", //
+                        "qute.command.generate.template.file", Arrays.asList(hello3FileUri)));
+    }
+
     public static Range r(int line, int startChar, int endChar) {
         return r(line, startChar, line, endChar);
     }

--- a/src/test/java/com/redhat/devtools/intellij/qute/psi/java/MavenJavaDiagnosticsTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/qute/psi/java/MavenJavaDiagnosticsTest.java
@@ -254,29 +254,6 @@ public class MavenJavaDiagnosticsTest extends QuteMavenModuleImportingTestCase {
                         DiagnosticSeverity.Error, "qute", QuteErrorCode.FragmentNotDefined.name()));
     }
 
-    public void testCheckedTemplateInInnerClassWithCustomBasePath() throws Exception {
-
-        QuteJavaDiagnosticsParams params = new QuteJavaDiagnosticsParams();
-        String javaFileUri = LSPIJUtils.toUri(module).resolve("src/main/java/org/acme/qute/ItemResourceWithCustomBasePath.java").toASCIIString();
-        params.setUris(Arrays.asList(javaFileUri));
-
-        List<PublishDiagnosticsParams> publishDiagnostics = QuteSupportForJava.getInstance().diagnostics(params,
-                PsiUtilsLSImpl.getInstance(myProject), new EmptyProgressIndicator());
-        assertEquals(1, publishDiagnostics.size());
-
-        List<Diagnostic> diagnostics = publishDiagnostics.get(0).getDiagnostics();
-        assertEquals(2, diagnostics.size());
-
-        assertDiagnostic(diagnostics, //
-                new Diagnostic(r(23, 33, 23, 43),
-                        "No template matching the path ItemResourceWithFragment/items3 could be found for: org.acme.qute.ItemResourceWithCustomBasePath$Templates",
-                        DiagnosticSeverity.Error, "qute", QuteErrorCode.NoMatchingTemplate.name()), //
-                new Diagnostic(r(24, 33, 24, 40),
-                        "Fragment [] not defined in template ItemResourceWithFragment/items3$",
-                        DiagnosticSeverity.Error, "qute", QuteErrorCode.FragmentNotDefined.name())
-                );
-    }
-
     @Test
     public void testTemplateRecord() throws Exception {
 
@@ -306,6 +283,37 @@ public class MavenJavaDiagnosticsTest extends QuteMavenModuleImportingTestCase {
                         DiagnosticSeverity.Error, "qute", QuteErrorCode.NoMatchingTemplate.name()));
     }
 
+    @Test
+    public void testCheckedTemplateWithDefaultName() throws Exception {
+
+        // @CheckedTemplate(defaultName=CheckedTemplate.HYPHENATED_ELEMENT_NAME)
+        // static class Templates {
+        // static native TemplateInstance HelloWorld(String name);
+
+        var module = loadMavenProject(QuteMavenProjectName.qute_record);
+        QuteJavaDiagnosticsParams params = new QuteJavaDiagnosticsParams();
+        String javaFileUri = LSPIJUtils.toUri(module).resolve("src/main/java/org/acme/sample/ItemResource.java").toASCIIString();
+        params.setUris(Arrays.asList(javaFileUri));
+
+        List<PublishDiagnosticsParams> publishDiagnostics = QuteSupportForJava.getInstance().diagnostics(params,
+                PsiUtilsLSImpl.getInstance(myProject), new EmptyProgressIndicator());
+
+        assertEquals(1, publishDiagnostics.size());
+
+        List<Diagnostic> diagnostics = publishDiagnostics.get(0).getDiagnostics();
+        assertEquals(3, diagnostics.size());
+
+        assertDiagnostic(diagnostics, //
+                new Diagnostic(r(19, 33, 19, 43),
+                        "No template matching the path ItemResource/HelloWorld could be found for: org.acme.sample.ItemResource$Templates",
+                        DiagnosticSeverity.Error, "qute", QuteErrorCode.NoMatchingTemplate.name()), //
+                new Diagnostic(r(25, 33, 25, 43),
+                        "No template matching the path ItemResource/HelloWorld could be found for: org.acme.sample.ItemResource$Templates2",
+                        DiagnosticSeverity.Error, "qute", QuteErrorCode.NoMatchingTemplate.name()), //
+                new Diagnostic(r(31, 33, 31, 43),
+                        "No template matching the path ItemResource/HelloWorld could be found for: org.acme.sample.ItemResource$Templates3",
+                        DiagnosticSeverity.Error, "qute", QuteErrorCode.NoMatchingTemplate.name()));
+    }
 
     public static Range r(int line, int startChar, int endChar) {
         return r(line, startChar, line, endChar);

--- a/src/test/java/com/redhat/devtools/intellij/qute/psi/java/MavenJavaDocumentLinkTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/qute/psi/java/MavenJavaDocumentLinkTest.java
@@ -308,6 +308,34 @@ public class MavenJavaDocumentLinkTest extends QuteMavenModuleImportingTestCase 
                         templateFileUri, "Create `src/main/resources/templates/Bonjour.html`"));
     }
 
+    @Test
+    public void testCheckedTemplateWithDefaultName() throws Exception {
+
+        // @CheckedTemplate(defaultName=CheckedTemplate.HYPHENATED_ELEMENT_NAME)
+        // static class Templates {
+        // static native TemplateInstance HelloWorld(String name);
+
+        var module = loadMavenProject(QuteMavenProjectName.qute_record);
+        QuteJavaDocumentLinkParams params = new QuteJavaDocumentLinkParams();
+        String javaFileUri = LSPIJUtils.toUri(module).resolve("src/main/java/org/acme/sample/ItemResource.java").toASCIIString();
+        params.setUri(javaFileUri);
+
+        List<DocumentLink> links = QuteSupportForJava.getInstance().documentLink(params, PsiUtilsLSImpl.getInstance(myProject),
+                new EmptyProgressIndicator());
+        assertEquals(3, links.size());
+
+        String helloFileUri = LSPIJUtils.toUri(module).resolve("src/main/resources/templates/ItemResource/HelloWorld.html").toASCIIString();
+        String hello2FileUri = LSPIJUtils.toUri(module).resolve("src/main/resources/templates/ItemResource/hello-world.html").toASCIIString();
+        String hello3FileUri = LSPIJUtils.toUri(module).resolve("src/main/resources/templates/ItemResource/hello_world.html").toASCIIString();
+
+        assertDocumentLink(links, //
+                dl(r(19, 33, 19, 43), //
+                        helloFileUri, "Create `src/main/resources/templates/ItemResource/HelloWorld.html`"), //
+                dl(r(25, 33, 25, 43), //
+                        hello2FileUri, "Create `src/main/resources/templates/ItemResource/hello-world.html`"), //
+                dl(r(31, 33, 31, 43), //
+                        hello3FileUri, "Create `src/main/resources/templates/ItemResource/hello_world.html`"));
+    }
 
     public static Range r(int line, int startChar, int endChar) {
         return r(line, startChar, line, endChar);

--- a/src/test/java/com/redhat/devtools/intellij/qute/psi/template/TemplateGetDataModelProjectTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/qute/psi/template/TemplateGetDataModelProjectTest.java
@@ -147,7 +147,7 @@ public class TemplateGetDataModelProjectTest extends QuteMavenModuleImportingTes
         Assert.assertNotNull(parameters);
 
         Assert.assertEquals(1, parameters.size());
-        assertParameter("items", "java.util.List<org.acme.qute.Item>", false, items);
+        assertParameter("items", "java.util.List<org.acme.qute.Item>", false, parameters, 0);
 
         // static native TemplateInstance map(Map<String, List<Item>> items,
         // Map.Entry<String, Integer> entry);
@@ -164,8 +164,8 @@ public class TemplateGetDataModelProjectTest extends QuteMavenModuleImportingTes
 
         Assert.assertEquals(2, parameters.size());
         assertParameter("items", "java.util.Map<java.lang.String,java.util.List<org.acme.qute.Item>>", false,
-                map);
-        assertParameter("entry", "java.util.Map$Entry<java.lang.String,java.lang.Integer>", false, map);
+                parameters, 0);
+        assertParameter("entry", "java.util.Map$Entry<java.lang.String,java.lang.Integer>", false, parameters, 1);
     }
 
     private static void checkedTemplate(DataModelProject<DataModelTemplate<DataModelParameter>> project) {
@@ -183,7 +183,7 @@ public class TemplateGetDataModelProjectTest extends QuteMavenModuleImportingTes
         // public static native TemplateInstance hello2(String name);
 
         Assert.assertEquals(1, hello2Parameters.size());
-        assertParameter("name", "java.lang.String", false, hello2Template);
+        assertParameter("name", "java.lang.String", false, hello2Parameters, 0);
 
         // hello3
         DataModelTemplate<DataModelParameter> hello3Template = project
@@ -199,7 +199,7 @@ public class TemplateGetDataModelProjectTest extends QuteMavenModuleImportingTes
         // public static native TemplateInstance hello3(String name);
 
         Assert.assertEquals(1, hello3Parameters.size());
-        assertParameter("name", "java.lang.String", false, hello3Template);
+        assertParameter("name", "java.lang.String", false, hello3Parameters, 0);
     }
 
     private static void testValueResolversFromTemplateExtension(List<ValueResolverInfo> resolvers) {
@@ -358,7 +358,7 @@ public class TemplateGetDataModelProjectTest extends QuteMavenModuleImportingTes
     }
 
     @Test
-    public void quarkus3() throws Exception {
+    public void testQuarkus3() throws Exception {
         loadMavenProject(QuteMavenProjectName.quarkus3);
 
         QuteDataModelProjectParams params = new QuteDataModelProjectParams(QuteMavenProjectName.quarkus3);
@@ -374,7 +374,7 @@ public class TemplateGetDataModelProjectTest extends QuteMavenModuleImportingTes
     }
 
     @Test
-    public void quteRecord() throws Exception {
+    public void testQuteRecord() throws Exception {
         loadMavenProject(QuteMavenProjectName.qute_record);
 
         QuteDataModelProjectParams params = new QuteDataModelProjectParams(QuteMavenProjectName.qute_record);
@@ -390,7 +390,7 @@ public class TemplateGetDataModelProjectTest extends QuteMavenModuleImportingTes
                 .findDataModelTemplate("src/main/resources/templates/Hello");
         Assert.assertNotNull(helloTemplate);
         Assert.assertEquals("src/main/resources/templates/Hello", helloTemplate.getTemplateUri());
-        Assert.assertEquals("org.acme.sample.HelloResource$Hello", helloTemplate.getSourceType());
+        Assert.assertEquals("org.acme.sample.HelloResource.Hello", helloTemplate.getSourceType());
         Assert.assertNull(helloTemplate.getSourceField());
         Assert.assertNull(helloTemplate.getSourceMethod());
 
@@ -405,6 +405,38 @@ public class TemplateGetDataModelProjectTest extends QuteMavenModuleImportingTes
         //  public TemplateInstance get(@QueryParam("name") String name) {
         // return new Hello(name).data("foo", 100);
         assertParameter("foo", "int", true, helloParameters, 1);
+    }
+
+    @Test
+    public void testCheckedTemplateWithDefaultName() throws Exception {
+        loadMavenProject(QuteMavenProjectName.qute_record);
+
+        QuteDataModelProjectParams params = new QuteDataModelProjectParams(QuteMavenProjectName.qute_record);
+        DataModelProject<DataModelTemplate<DataModelParameter>> project = QuteSupportForTemplate.getInstance()
+                .getDataModelProject(params, getJDTUtils(), new EmptyProgressIndicator());
+        Assert.assertNotNull(project);
+
+        // public class HelloResource {
+        // record Hello(String name) implements TemplateInstance {}
+
+        // Hello
+        DataModelTemplate<DataModelParameter> helloTemplate = project
+                .findDataModelTemplate("src/main/resources/templates/ItemResource/hello-world.html");
+        Assert.assertNotNull(helloTemplate);
+        Assert.assertEquals("src/main/resources/templates/ItemResource/hello-world", helloTemplate.getTemplateUri());
+        Assert.assertEquals("org.acme.sample.ItemResource$Templates2", helloTemplate.getSourceType());
+        Assert.assertEquals("HelloWorld", helloTemplate.getSourceMethod());
+        Assert.assertNull(helloTemplate.getSourceField());
+
+        List<DataModelParameter> helloParameters = helloTemplate.getParameters();
+        Assert.assertNotNull(helloParameters);
+
+        Assert.assertEquals(1, helloParameters.size());
+
+        // static class Templates2 {
+        // static native TemplateInstance HelloWorld(String name);
+        assertParameter("name", "java.lang.String", false, helloParameters, 0);
+
     }
 
 }


### PR DESCRIPTION
feat: Qute: Cannot locate hyphenated template name

Fixes https://github.com/redhat-developer/quarkus-ls/issues/975

You can play with the qute-record test project:

![image](https://github.com/user-attachments/assets/c92310f7-44c0-4fe7-8d77-6b70f5c3e771)


//cc @gbourant