### PR TITLE
feat: Workspace symbols for JAX-RS endpoints

### DIFF
--- a/projects/lsp4mp/projects/maven/config-quickstart/src/main/java/org/acme/config/GreetingResource.java
+++ b/projects/lsp4mp/projects/maven/config-quickstart/src/main/java/org/acme/config/GreetingResource.java
@@ -3,6 +3,7 @@ package org.acme.config;
 import java.util.Optional;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.PATCH;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
@@ -39,5 +40,10 @@ public class GreetingResource {
     @Path("hello4")
     public String hello3() {
         return message + " 4 " + name.orElse("world") + suffix;
+    }
+
+    @PATCH
+    @Path("hello5")
+    public String hello5() {
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/java/codelens/IJavaCodeLensParticipant.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/java/codelens/IJavaCodeLensParticipant.java
@@ -26,7 +26,8 @@ import java.util.List;
  *
  */
 public interface IJavaCodeLensParticipant {
-	public static final ExtensionPointName<IJavaCodeLensParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaCodeLensParticipant");
+
+	ExtensionPointName<IJavaCodeLensParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaCodeLensParticipant");
 
 
 	/**

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/java/completion/IJavaCompletionParticipant.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/java/completion/IJavaCompletionParticipant.java
@@ -24,7 +24,8 @@ import org.eclipse.lsp4j.CompletionItem;
  * @author datho7561
  */
 public interface IJavaCompletionParticipant {
-	public static final ExtensionPointName<IJavaCompletionParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaCompletionParticipant");
+
+	ExtensionPointName<IJavaCompletionParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaCompletionParticipant");
 
 	/**
 	 * Returns true if this completion feature should be active in this context, and false otherwise

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/java/definition/IJavaDefinitionParticipant.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/java/definition/IJavaDefinitionParticipant.java
@@ -25,7 +25,8 @@ import java.util.List;
  *
  */
 public interface IJavaDefinitionParticipant {
-	public static final ExtensionPointName<IJavaDefinitionParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaDefinitionParticipant");
+
+	ExtensionPointName<IJavaDefinitionParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaDefinitionParticipant");
 
 	/**
 	 * Returns true if definition must be collected for the given context and false

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/java/diagnostics/IJavaDiagnosticsParticipant.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/java/diagnostics/IJavaDiagnosticsParticipant.java
@@ -25,7 +25,7 @@ import org.eclipse.lsp4j.Diagnostic;
  */
 public interface IJavaDiagnosticsParticipant {
 
-	public static final ExtensionPointName<IJavaDiagnosticsParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaDiagnosticsParticipant");
+	ExtensionPointName<IJavaDiagnosticsParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaDiagnosticsParticipant");
 
 	/**
 	 * Returns true if diagnostics must be collected for the given context and false

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/java/hover/IJavaHoverParticipant.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/java/hover/IJavaHoverParticipant.java
@@ -23,7 +23,7 @@ import org.eclipse.lsp4j.Hover;
  */
 public interface IJavaHoverParticipant {
 
-	public static final ExtensionPointName<IJavaHoverParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaHoverParticipant");
+	ExtensionPointName<IJavaHoverParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaHoverParticipant");
 
 	/**
 	 * Returns true if hover must be collected for the given context and false

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/java/symbols/IJavaWorkspaceSymbolsParticipant.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/java/symbols/IJavaWorkspaceSymbolsParticipant.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Red Hat Inc. and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.intellij.lsp4mp4ij.psi.core.java.symbols;
+
+import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import org.eclipse.lsp4j.SymbolInformation;
+
+import java.util.List;
+
+/**
+ * Represents an object that can collect workspace symbols for java projects.
+ */
+public interface IJavaWorkspaceSymbolsParticipant {
+
+    ExtensionPointName<IJavaWorkspaceSymbolsParticipant> EP_NAME = ExtensionPointName.create("com.redhat.devtools.intellij.quarkus.javaWorkspaceSymbolsParticipant");
+
+    /**
+     * Fill in <code>symbols</code> with workspace symbols of the given project.
+     *
+     * @param project the project to collect workspace symbols from
+     * @param utils   the JDT utils
+     * @param symbols the list of symbols to add to
+     * @param monitor the progress monitor
+     */
+    void collectSymbols(Module project, IPsiUtils utils, List<SymbolInformation> symbols,
+                        ProgressIndicator monitor);
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/jaxrs/IJaxRsInfoProvider.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/jaxrs/IJaxRsInfoProvider.java
@@ -43,15 +43,17 @@ public interface IJaxRsInfoProvider {
 	 * Returns a non-null set of all the classes in the given project that this provider can provide JAX-RS method information for.
 	 *
 	 * @param javaProject the project to check for JAX-RS method information
+	 * @param utils the Psi utilities.
 	 * @param monitor the progress monitor
 	 * @return a non-null set of all the classes in the given project that this provider can provide JAX-RS method information for
 	 */
-	@NotNull Set<PsiClass> getAllJaxRsClasses(@NotNull Module javaProject, @NotNull ProgressIndicator monitor);
+	@NotNull Set<PsiClass> getAllJaxRsClasses(@NotNull Module javaProject, @NotNull IPsiUtils utils, @NotNull ProgressIndicator monitor);
 
 	/**
 	 * Returns a list of all the JAX-RS methods in the given type.
 	 *
 	 * @param type    the type to check for JAX-RS methods
+	 * @param jaxrsContext the JAX-RS context.
 	 * @param monitor the progress monitor
 	 * @return a list of all the JAX-RS methods in the given type
 	 */

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsInfoProviderRegistry.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsInfoProviderRegistry.java
@@ -62,7 +62,7 @@ public class JaxRsInfoProviderRegistry {
         return null;
     }
 
-    private List<IJaxRsInfoProvider> getProviders() {
+    public List<IJaxRsInfoProvider> getProviders() {
         if (!initialized) {
             providers = loadProviders();
             return providers;

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.jaxrs.java;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiClass;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.java.symbols.IJavaWorkspaceSymbolsParticipant;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.jaxrs.IJaxRsInfoProvider;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.jaxrs.JaxRsContext;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.jaxrs.JaxRsMethodInfo;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.SymbolKind;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Collects workspace symbols for JAX-RS REST endpoints.
+ */
+public class JaxRsWorkspaceSymbolParticipant implements IJavaWorkspaceSymbolsParticipant {
+
+	private static final Logger LOGGER = Logger.getLogger(JaxRsWorkspaceSymbolParticipant.class.getName());
+
+	@Override
+	public void collectSymbols(Module project, IPsiUtils utils, List<SymbolInformation> symbols, ProgressIndicator monitor) {
+		if (monitor.isCanceled()) {
+			return;
+		}
+
+		JaxRsContext jaxrsContext = new JaxRsContext(project);
+		Set<PsiClass> jaxrsTypes = getAllJaxRsTypes(project, utils, monitor);
+		if (jaxrsTypes == null || monitor.isCanceled()) {
+			return;
+		}
+		List<JaxRsMethodInfo> methodsInfo = new ArrayList<>();
+		for (PsiClass typeRoot : jaxrsTypes) {
+			IJaxRsInfoProvider provider = getProviderForType(typeRoot, project, monitor);
+			if (provider != null) {
+				methodsInfo.addAll(provider.getJaxRsMethodInfo(typeRoot.getContainingFile(), jaxrsContext, utils, monitor));
+			}
+			if (monitor.isCanceled()) {
+				return;
+			}
+		}
+
+		methodsInfo.forEach(methodInfo -> {
+			try {
+				symbols.add(createSymbol(methodInfo, utils));
+			} catch (Exception e) {
+				LOGGER.log(Level.WARNING, "failed to create workspace symbol for jax-rs method", e);
+			}
+		});
+	}
+
+	/**
+	 * Returns the provider that can provide JAX-RS method info for the given class,
+	 * or null if no provider can provide info.
+	 *
+	 * @param typeRoot the class to collect JAX-RS method info for
+	 * @param project the Module project
+	 * @param monitor the progress monitor
+	 * @return the provider that can provide JAX-RS method info for the given class,
+	 *         or null if no provider can provide info
+	 */
+	private static IJaxRsInfoProvider getProviderForType(PsiClass typeRoot, Module project,  ProgressIndicator monitor) {
+		for (IJaxRsInfoProvider provider : JaxRsInfoProviderRegistry.getInstance().getProviders()) {
+			if (provider.canProvideJaxRsMethodInfoForClass(typeRoot.getContainingFile(), project, monitor)) {
+				return provider;
+			}
+		}
+		LOGGER.severe("Attempted to collect JAX-RS info for " + typeRoot.getQualifiedName()
+				+ ", but no participant was suitable, despite the fact that an earlier check found a suitable participant");
+		return null;
+	}
+
+	private static Set<PsiClass> getAllJaxRsTypes(Module javaProject, IPsiUtils utils, ProgressIndicator monitor) {
+		Set<PsiClass> jaxrsTypes = new HashSet<>();
+		for (IJaxRsInfoProvider provider : JaxRsInfoProviderRegistry.getInstance().getProviders()) {
+			jaxrsTypes.addAll(provider.getAllJaxRsClasses(javaProject, utils,monitor));
+			if (monitor.isCanceled()) {
+				return null;
+			}
+		}
+		return jaxrsTypes;
+	}
+
+	private static SymbolInformation createSymbol(JaxRsMethodInfo methodInfo, IPsiUtils utils) throws MalformedURLException {
+		TextRange sourceRange = methodInfo.getJavaMethod().getNameIdentifier().getTextRange();
+		Range r = utils.toRange(methodInfo.getJavaMethod(), sourceRange.getStartOffset(), sourceRange.getLength());
+		Location location = new Location(methodInfo.getDocumentUri(), r);
+
+		StringBuilder nameBuilder = new StringBuilder("@");
+		URL url = new URL(methodInfo.getUrl());
+		String path = url.getPath();
+		nameBuilder.append(path);
+		nameBuilder.append(": ");
+		nameBuilder.append(methodInfo.getHttpMethod());
+
+		SymbolInformation symbol = new SymbolInformation();
+		symbol.setName(nameBuilder.toString());
+		symbol.setKind(SymbolKind.Method);
+		symbol.setLocation(location);
+		return symbol;
+	}
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusLanguageClient.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusLanguageClient.java
@@ -267,8 +267,8 @@ public class QuarkusLanguageClient extends IndexAwareLanguageClient implements M
 
     @Override
     public CompletableFuture<List<SymbolInformation>> getJavaWorkspaceSymbols(String projectUri) {
-        //Workspace symbols not supported yet https://github.com/redhat-developer/intellij-quarkus/issues/808
-        return CompletableFuture.completedFuture(null);
+        var coalesceBy = new CoalesceByKey("microprofile/java/workspaceSymbols", projectUri);
+        return runAsBackground("Computing Java workspace symbols", monitor -> PropertiesManagerForJava.getInstance().workspaceSymbols(projectUri, PsiUtilsLSImpl.getInstance(getProject()), monitor), coalesceBy);
     }
 
     @Override

--- a/src/main/java/com/redhat/microprofile/psi/internal/quarkus/renarde/java/RenardeJaxRsInfoProvider.java
+++ b/src/main/java/com/redhat/microprofile/psi/internal/quarkus/renarde/java/RenardeJaxRsInfoProvider.java
@@ -20,6 +20,7 @@ import com.intellij.util.KeyedLazyInstanceEP;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.jaxrs.*;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -40,18 +41,24 @@ public class RenardeJaxRsInfoProvider extends KeyedLazyInstanceEP<IJaxRsInfoProv
 	private static final Logger LOGGER = Logger.getLogger(RenardeJaxRsInfoProvider.class.getName());
 
 	@Override
-	public boolean canProvideJaxRsMethodInfoForClass(PsiFile typeRoot, Module javaProject, ProgressIndicator monitor) {
+	public boolean canProvideJaxRsMethodInfoForClass(@NotNull PsiFile typeRoot,
+													 @NotNull Module javaProject,
+													 @NotNull ProgressIndicator monitor) {
 		return RenardeUtils.isControllerClass(javaProject, typeRoot, monitor);
 	}
 
 	@Override
-	public Set<PsiClass> getAllJaxRsClasses(Module javaProject, ProgressIndicator monitor) {
+	public @NotNull Set<PsiClass> getAllJaxRsClasses(@NotNull Module javaProject,
+											@NotNull IPsiUtils utils,
+											@NotNull ProgressIndicator monitor) {
 		return RenardeUtils.getAllControllerClasses(javaProject, monitor);
 	}
 
 	@Override
-	public List<JaxRsMethodInfo> getJaxRsMethodInfo(PsiFile typeRoot, JaxRsContext jaxrsContext, IPsiUtils utils,
-													ProgressIndicator monitor) {
+	public @NotNull List<JaxRsMethodInfo> getJaxRsMethodInfo(@NotNull PsiFile typeRoot,
+															 @NotNull JaxRsContext jaxrsContext,
+															 @NotNull IPsiUtils utils,
+															 @NotNull ProgressIndicator monitor) {
 		try {
 			PsiClass type = findFirstClass(typeRoot);
 			if (type == null) {

--- a/src/main/java/com/redhat/microprofile/psi/internal/quarkus/renarde/java/RenardeUtils.java
+++ b/src/main/java/com/redhat/microprofile/psi/internal/quarkus/renarde/java/RenardeUtils.java
@@ -12,6 +12,8 @@
 package com.redhat.microprofile.psi.internal.quarkus.renarde.java;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import com.intellij.openapi.module.Module;
@@ -19,6 +21,9 @@ import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.impl.source.PsiClassReferenceType;
+import com.intellij.psi.search.ProjectScope;
+import com.intellij.psi.search.searches.DefinitionsScopedSearch;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.PsiTypeUtils;
 import org.jetbrains.annotations.NotNull;
@@ -87,8 +92,19 @@ public class RenardeUtils {
 	 * <code>Controller</code> class
 	 */
 	public static Set<PsiClass> getAllControllerClasses(Module project, ProgressIndicator monitor) {
-		// TODO: implement when LSP4IJ will support workspace symbols
-		return Collections.emptySet();
+		PsiClass renardeControllerType = PsiTypeUtils.findType(project, RenardeConstants.CONTROLLER_FQN);
+		if (renardeControllerType == null) {
+			return Collections.emptySet();
+		}
+
+		Set<PsiClass> types = new HashSet<>();
+		DefinitionsScopedSearch.search(renardeControllerType, ProjectScope.getAllScope(project.getProject()), true)
+				.forEach(element -> {
+					if (element instanceof PsiClass renardeType) {
+						types.add(renardeType);
+					}
+				});
+		return types;
 	}
 
 }

--- a/src/main/java/com/redhat/microprofile/psi/internal/quarkus/route/java/ReactiveRouteJaxRsInfoProvider.java
+++ b/src/main/java/com/redhat/microprofile/psi/internal/quarkus/route/java/ReactiveRouteJaxRsInfoProvider.java
@@ -21,6 +21,7 @@ import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.jaxrs.*;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.PsiTypeUtils;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,12 +45,12 @@ public class ReactiveRouteJaxRsInfoProvider extends KeyedLazyInstanceEP<IJaxRsIn
     private static final Logger LOGGER = Logger.getLogger(ReactiveRouteJaxRsInfoProvider.class.getName());
 
     @Override
-    public boolean canProvideJaxRsMethodInfoForClass(PsiFile typeRoot, Module javaProject, ProgressIndicator monitor) {
+    public boolean canProvideJaxRsMethodInfoForClass(@NotNull PsiFile typeRoot, Module javaProject, ProgressIndicator monitor) {
         return PsiTypeUtils.findType(javaProject, ROUTE_FQN) != null;
     }
 
     @Override
-    public Set<PsiClass> getAllJaxRsClasses(Module javaProject, ProgressIndicator monitor) {
+    public Set<PsiClass> getAllJaxRsClasses(@NotNull Module javaProject, @NotNull IPsiUtils utils, @NotNull ProgressIndicator monitor) {
         // TODO: implement when LSP4IJ will support workspace symbols
         return Collections.emptySet();
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -432,7 +432,8 @@
         </extensionPoint>
         <extensionPoint name="jaxRsInfoProvider"
                         interface="com.redhat.devtools.intellij.lsp4mp4ij.psi.core.jaxrs.IJaxRsInfoProvider"/>
-
+        <extensionPoint name="javaWorkspaceSymbolsParticipant"
+                        interface="com.redhat.devtools.intellij.lsp4mp4ij.psi.core.java.symbols.IJavaWorkspaceSymbolsParticipant"/>
         <!-- Qute -->
         <extensionPoint name="qute.dataModelProvider"
                         beanClass="com.redhat.devtools.intellij.qute.psi.internal.template.datamodel.DataModelProviderRegistry$DataModelProviderBean">
@@ -537,6 +538,8 @@
                                    implementationClass="com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.restclient.java.RegisterRestClientAnnotationMissingQuickFix"/>
         <javaCodeActionParticipant kind="source"
                                    implementationClass="com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.openapi.java.MicroProfileGenerateOpenAPIOperation"/>
+
+        <javaWorkspaceSymbolsParticipant implementation="com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.jaxrs.java.JaxRsWorkspaceSymbolParticipant" />
 
         <!-- Microprofile Config Static Property support -->
         <staticPropertyProvider resource="/static-properties/mp-config-metadata.json"

--- a/src/test/java/com/redhat/microprofile/psi/quarkus/jaxrs/JaxRsWorkspaceSymbolParticipantTest.java
+++ b/src/test/java/com/redhat/microprofile/psi/quarkus/jaxrs/JaxRsWorkspaceSymbolParticipantTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.psi.quarkus.jaxrs;
+
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileForJavaAssert.assertWorkspaceSymbols;
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileForJavaAssert.si;
+import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileForJavaAssert.r;
+
+import com.intellij.openapi.module.Module;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.LSP4MPMavenModuleImportingTestCase;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileMavenProjectName;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
+import org.junit.Test;
+
+/**
+ * Tests for <code>JaxRsWorkspaceSymbolParticipantTest</code>.
+ */
+public class JaxRsWorkspaceSymbolParticipantTest extends LSP4MPMavenModuleImportingTestCase {
+
+	@Test
+	public void testConfigQuickstart() throws Exception {
+		Module javaProject = loadMavenProject(MicroProfileMavenProjectName.config_quickstart);
+
+		assertWorkspaceSymbols(javaProject, PsiUtilsLSImpl.getInstance(myProject), //
+				si("@/greeting/hello4: GET", r(40, 18, 24)), //
+				si("@/greeting/constructor: GET", r(34, 18, 23)), //
+				si("@/greeting/hello: GET", r(33, 18, 24)), //
+				si("@/greeting: GET", r(26, 18, 23)), //
+				si("@/greeting/method: GET", r(38, 18, 23)), //
+				si("@/greeting/hello5: PATCH", r(46, 18, 24)));
+	}
+
+	@Test
+	public void testOpenLiberty() throws Exception {
+		Module javaProject = loadMavenProject(MicroProfileMavenProjectName.open_liberty);
+
+		assertWorkspaceSymbols(javaProject, PsiUtilsLSImpl.getInstance(myProject), //
+				si("@/api/api/resource: GET", r(13, 15, 20)));
+	}
+
+}

--- a/src/test/java/com/redhat/microprofile/psi/quarkus/renarde/RenardeJaxRsTest.java
+++ b/src/test/java/com/redhat/microprofile/psi/quarkus/renarde/RenardeJaxRsTest.java
@@ -1,14 +1,14 @@
 /*******************************************************************************
-* Copyright (c) 2023 Red Hat Inc. and others.
-* All rights reserved. This program and the accompanying materials
-* which accompanies this distribution, and is available at
-* http://www.eclipse.org/legal/epl-v20.html
-*
-* SPDX-License-Identifier: EPL-2.0
-*
-* Contributors:
-*     Red Hat Inc. - initial API and implementation
-*******************************************************************************/
+ * Copyright (c) 2023 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
 package com.redhat.microprofile.psi.quarkus.renarde;
 
 import com.intellij.openapi.module.Module;
@@ -26,65 +26,72 @@ import static com.redhat.devtools.intellij.lsp4mp4ij.psi.core.MicroProfileForJav
  */
 public class RenardeJaxRsTest extends QuarkusMavenModuleImportingTestCase {
 
-	@Test
-	public void testCodeLens() throws Exception {
-		Module javaProject = loadMavenProject(QuarkusMavenProjectName.quarkus_renarde_todo);
-		assertNotNull(javaProject);
+    @Test
+    public void testCodeLens() throws Exception {
+        Module javaProject = loadMavenProject(QuarkusMavenProjectName.quarkus_renarde_todo);
+        assertNotNull(javaProject);
 
-		MicroProfileJavaCodeLensParams params = new MicroProfileJavaCodeLensParams();
-		params.setCheckServerAvailable(false);
-		String javaFileUri = getFileUri("src/main/java/rest/Application.java", javaProject);
-		params.setUri(javaFileUri);
-		params.setUrlCodeLensEnabled(true);
+        MicroProfileJavaCodeLensParams params = new MicroProfileJavaCodeLensParams();
+        params.setCheckServerAvailable(false);
+        String javaFileUri = getFileUri("src/main/java/rest/Application.java", javaProject);
+        params.setUri(javaFileUri);
+        params.setUrlCodeLensEnabled(true);
 
-		assertCodeLens(params, PsiUtilsLSImpl.getInstance(myProject), //
-				cl("http://localhost:8080/", "", r(20, 4, 4)), //
-				cl("http://localhost:8080/about", "", r(25, 4, 4)), //
-				cl("http://localhost:8080/Application/test", "", r(30, 4, 4)), //
-				cl("http://localhost:8080/Application/endpoint", "", r(34, 4, 4)));
-	}
+        assertCodeLens(params, PsiUtilsLSImpl.getInstance(myProject), //
+                cl("http://localhost:8080/", "", r(20, 4, 4)), //
+                cl("http://localhost:8080/about", "", r(25, 4, 4)), //
+                cl("http://localhost:8080/Application/test", "", r(30, 4, 4)), //
+                cl("http://localhost:8080/Application/endpoint", "", r(34, 4, 4)));
+    }
 
-	@Test
-	public void testAbsolutePathCodeLens() throws Exception {
-		Module javaProject = loadMavenProject(QuarkusMavenProjectName.quarkus_renarde_todo);
+    @Test
+    public void testAbsolutePathCodeLens() throws Exception {
+        Module javaProject = loadMavenProject(QuarkusMavenProjectName.quarkus_renarde_todo);
 
-		assertNotNull(javaProject);
+        assertNotNull(javaProject);
 
-		MicroProfileJavaCodeLensParams params = new MicroProfileJavaCodeLensParams();
-		params.setCheckServerAvailable(false);
-		String javaFileUri = getFileUri("src/main/java/rest/Game.java", javaProject);
-		params.setUri(javaFileUri);
-		params.setUrlCodeLensEnabled(true);
+        MicroProfileJavaCodeLensParams params = new MicroProfileJavaCodeLensParams();
+        params.setCheckServerAvailable(false);
+        String javaFileUri = getFileUri("src/main/java/rest/Game.java", javaProject);
+        params.setUri(javaFileUri);
+        params.setUrlCodeLensEnabled(true);
 
-		assertCodeLens(params, PsiUtilsLSImpl.getInstance(myProject), //
-				cl("http://localhost:8080/play/id", "", r(9, 4, 4)),
-				cl("http://localhost:8080/play/start", "", r(13, 4, 4)));
-	}
+        assertCodeLens(params, PsiUtilsLSImpl.getInstance(myProject), //
+                cl("http://localhost:8080/play/id", "", r(9, 4, 4)),
+                cl("http://localhost:8080/play/start", "", r(13, 4, 4)));
+    }
 
-	/*@Test
-	public void workspaceSymbols() throws Exception {
-		IJavaProject javaProject = loadMavenProject(quarkus_renarde_todo);
+    @Test
+    public void testWorkspaceSymbols() throws Exception {
+        Module javaProject = loadMavenProject(QuarkusMavenProjectName.quarkus_renarde_todo);
 
-		assertNotNull(javaProject);
+        assertNotNull(javaProject);
 
-		assertWorkspaceSymbols(javaProject, JDT_UTILS, //
-				si("@/: GET", r(20, 28, 33)), //
-				si("@/Application/endpoint: GET", r(34, 18, 26)), //
-				si("@/Application/test: POST", r(30, 16, 20)), //
-				si("@/Login/complete: POST", r(174, 20, 28)), //
-				si("@/Login/confirm: GET", r(138, 28, 35)), //
-				si("@/Login/login: GET", r(57, 28, 33)), //
-				si("@/Login/logoutFirst: GET", r(153, 28, 39)), //
-				si("@/Login/manualLogin: POST", r(73, 20, 31)), //
-				si("@/Login/register: POST", r(118, 28, 36)), //
-				si("@/Login/welcome: GET", r(65, 28, 35)), //
-				si("@/Todos/add: POST", r(59, 16, 19)), //
-				si("@/Todos/delete: POST", r(35, 16, 22)), //
-				si("@/Todos/done: POST", r(46, 16, 20)), //
-				si("@/Todos/index: GET", r(29, 28, 33)), //
-				si("@/about: GET", r(25, 28, 33)), //
-				si("@/play/id: GET", r(9, 18, 26)), //
-				si("@/play/start: GET", r(13, 18, 23)));
-	}*/
+        assertWorkspaceSymbols(javaProject, PsiUtilsLSImpl.getInstance(myProject), //
+                si("@/: GET", r(20, 28, 33)), //
+                si("@/Application/endpoint: GET", r(34, 18, 26)), //
+                si("@/Application/test: POST", r(30, 16, 20)), //
+                si("@/Login/complete: POST", r(174, 20, 28)), //
+                si("@/Login/confirm: GET", r(138, 28, 35)), //
+                si("@/Login/login: GET", r(57, 28, 33)), //
+                si("@/Login/logoutFirst: GET", r(153, 28, 39)), //
+                si("@/Login/manualLogin: POST", r(73, 20, 31)), //
+                si("@/Login/register: POST", r(118, 28, 36)), //
+                si("@/Login/welcome: GET", r(65, 28, 35)), //
+                si("@/Todos/add: POST", r(59, 16, 19)), //
+                si("@/Todos/delete: POST", r(35, 16, 22)), //
+                si("@/Todos/done: POST", r(46, 16, 20)), //
+                si("@/Todos/index: GET", r(29, 28, 33)), //
+                si("@/about: GET", r(25, 28, 33)), //
+                si("@/play/id: GET", r(9, 18, 26)), //
+                si("@/play/start: GET", r(13, 18, 23)), //
+                // From Renarde JAR
+                si("@/_renarde/security/login-{provider}: GET", r(24, 16, 30)),
+                si("@/_renarde/security/logout: GET", r(27, 37, 43)),
+                si("@/_renarde/security/github-success: GET", r(31, 16, 29)),
+                si("@/_renarde/security/twitter-success: GET", r(35, 16, 30)),
+                si("@/_renarde/security/oidc-success: GET", r(39, 16, 30)),
+                si("@/_renarde/security/oidc-success: POST", r(44, 16, 31)));
+    }
 
 }


### PR DESCRIPTION
feat: Workspace symbols for JAX-RS endpoints

Fixes #1363

This PR provides JAX-RS and Renarde workspace symbol. For Renarde it uses the scope (if you select Project And Libraries scope you can see Renarde controller declared in the JAR Renarde):

![image](https://github.com/user-attachments/assets/54f62a1b-bca1-43fd-a0f9-7953410f712f)


//cc @ia3andy 