### PR TITLE
feat: New Feature: outline extension BuildItems

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/psi/internal/builditems/QuarkusBuildItemUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/psi/internal/builditems/QuarkusBuildItemUtils.java
@@ -1,0 +1,53 @@
+package com.redhat.devtools.intellij.quarkus.psi.internal.builditems;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.psi.PsiClass;
+import com.intellij.psi.PsiModifier;
+import com.intellij.psi.search.ProjectScope;
+import com.intellij.psi.search.searches.DefinitionsScopedSearch;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.PsiTypeUtils;
+import com.redhat.devtools.intellij.quarkus.QuarkusConstants;
+import com.redhat.microprofile.psi.internal.quarkus.renarde.java.RenardeConstants;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class QuarkusBuildItemUtils {
+
+    private QuarkusBuildItemUtils() {
+
+    }
+
+    /**
+     * Returns a set of all classes in the given project that extend Renarde's
+     * <code>Controller</code> class.
+     *
+     * @param project the project to search in
+     * @param monitor the progress monitor
+     * @return a set of all classes in the given project that extend Renarde's
+     * <code>Controller</code> class
+     */
+    public static Set<PsiClass> getAllBuildItemClasses(Module project, ProgressIndicator monitor) {
+        PsiClass buildItemType = PsiTypeUtils.findType(project, QuarkusConstants.QUARKUS_BUILD_ITEM_CLASS_NAME);
+        if (buildItemType == null) {
+            return Collections.emptySet();
+        }
+
+        Set<PsiClass> types = new HashSet<>();
+        DefinitionsScopedSearch.search(buildItemType, ProjectScope.getAllScope(project.getProject()), true)
+                .forEach(element -> {
+                    if (element instanceof PsiClass type && isValidBuildItem(type)) {
+                        types.add(type);
+                    }
+                });
+        return types;
+    }
+
+
+    public static boolean isValidBuildItem(PsiClass psiClass) {
+        return psiClass.hasModifierProperty(PsiModifier.FINAL)
+                || psiClass.hasModifierProperty(PsiModifier.ABSTRACT);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/psi/internal/validators/QuarkusBuildItemDiagnosticsParticipant.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/psi/internal/validators/QuarkusBuildItemDiagnosticsParticipant.java
@@ -33,6 +33,8 @@ import org.eclipse.lsp4mp.commons.DocumentFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.redhat.devtools.intellij.quarkus.psi.internal.builditems.QuarkusBuildItemUtils.isValidBuildItem;
+
 /**
  * Validates <code>io.quarkus.builder.item.BuildItem</code> subclasses.
  * <ul>
@@ -77,9 +79,7 @@ public class QuarkusBuildItemDiagnosticsParticipant implements IJavaDiagnosticsP
     }
 
     private static void validateBuildItem(PsiClass psiClass, List<Diagnostic> diagnostics, JavaDiagnosticsContext context) {
-        if (psiClass.hasModifierProperty(PsiModifier.FINAL)
-        || psiClass.hasModifierProperty(PsiModifier.ABSTRACT)
-        ) {
+        if (isValidBuildItem(psiClass)) {
             return;
         }
         Range range = PositionUtils.toClassDeclarationRange(psiClass, context.getUtils());
@@ -93,7 +93,7 @@ public class QuarkusBuildItemDiagnosticsParticipant implements IJavaDiagnosticsP
     }
 
     private static String createDiagnosticMessage(PsiClass classType, DocumentFormat documentFormat) {
-        String quote = DocumentFormat.Markdown.equals(documentFormat)?"`":"'";
+        String quote = DocumentFormat.Markdown.equals(documentFormat) ? "`" : "'";
         return String.format(INVALID_MODIFIER, classType.getQualifiedName(), quote);
     }
 }

--- a/src/main/java/com/redhat/microprofile/psi/internal/quarkus/builditems/java/BuildItemWorkspaceSymbolParticipant.java
+++ b/src/main/java/com/redhat/microprofile/psi/internal/quarkus/builditems/java/BuildItemWorkspaceSymbolParticipant.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+* Copyright (c) 2024 Red Hat Inc. and others.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License v. 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+* which is available at https://www.apache.org/licenses/LICENSE-2.0.
+*
+* SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package com.redhat.microprofile.psi.internal.quarkus.builditems.java;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiClass;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.java.symbols.IJavaWorkspaceSymbolsParticipant;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.jaxrs.IJaxRsInfoProvider;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.jaxrs.JaxRsContext;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.jaxrs.JaxRsMethodInfo;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.jaxrs.java.JaxRsInfoProviderRegistry;
+import com.redhat.devtools.intellij.quarkus.psi.internal.builditems.QuarkusBuildItemUtils;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.SymbolKind;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Collects workspace symbols for Quarkus BuildItem.
+ */
+public class BuildItemWorkspaceSymbolParticipant implements IJavaWorkspaceSymbolsParticipant {
+
+	private static final Logger LOGGER = Logger.getLogger(BuildItemWorkspaceSymbolParticipant.class.getName());
+
+	@Override
+	public void collectSymbols(Module project, IPsiUtils utils, List<SymbolInformation> symbols, ProgressIndicator monitor) {
+		if (monitor.isCanceled()) {
+			return;
+		}
+
+		QuarkusBuildItemUtils.getAllBuildItemClasses(project, monitor)
+				.forEach(buildType -> {
+					symbols.add(createSymbol(buildType, utils ));
+				});
+	}
+
+	private static SymbolInformation createSymbol(PsiClass buildItemType, IPsiUtils utils) {
+		Location location = utils.toLocation(buildItemType);
+
+		StringBuilder nameBuilder = new StringBuilder("&");
+		nameBuilder.append(buildItemType.getName());
+
+		SymbolInformation symbol = new SymbolInformation();
+		symbol.setName(nameBuilder.toString());
+		symbol.setKind(SymbolKind.Class);
+		symbol.setLocation(location);
+		return symbol;
+	}
+
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -540,6 +540,7 @@
                                    implementationClass="com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.openapi.java.MicroProfileGenerateOpenAPIOperation"/>
 
         <javaWorkspaceSymbolsParticipant implementation="com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.jaxrs.java.JaxRsWorkspaceSymbolParticipant" />
+        <javaWorkspaceSymbolsParticipant implementation="com.redhat.microprofile.psi.internal.quarkus.builditems.java.BuildItemWorkspaceSymbolParticipant" />
 
         <!-- Microprofile Config Static Property support -->
         <staticPropertyProvider resource="/static-properties/mp-config-metadata.json"


### PR DESCRIPTION
feat: New Feature: outline extension BuildItems

Fixes #1094

Here a demo with the current PR:

![BuildItemWorkspaceSymbols](https://github.com/user-attachments/assets/cfe88ce5-6caa-46a3-bb00-cae929706f19)

Here how it works:

 * you need to open a Java file to start the MicroProfile Language Server (it doesn"t work if the language server is not started). To fix this issue, LSP4IJ must be improved with https://github.com/redhat-developer/lsp4ij/issues/439
 * you need to select `Project and libraries` in the scope to retrieve BuildItem from the JARs
 * As symbols is used for a lot of things like Java class, I decided to fill the list with BuildItem which starts with `&`

@gastaldi what do you think about that and the demo? Is it enough? Do you need more things?