### PR TITLE
fix: bumped telemetry to 1.2.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ platformType=IC
 platformVersion=2023.2
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins=com.intellij.java, maven, gradle-java, properties, yaml,  com.redhat.devtools.intellij.telemetry:1.1.0.52
+platformPlugins=com.intellij.java, maven, gradle-java, properties, yaml,  com.redhat.devtools.intellij.telemetry:1.2.1.62
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion=8.6
 channel=nightly

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/TelemetryService.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/TelemetryService.java
@@ -10,6 +10,7 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.quarkus;
 
+import com.intellij.ide.plugins.PluginManager;
 import com.redhat.devtools.intellij.telemetry.core.service.TelemetryMessageBuilder;
 import com.redhat.devtools.intellij.telemetry.core.util.Lazy;
 
@@ -24,7 +25,9 @@ public class TelemetryService {
 
     private static final TelemetryService INSTANCE = new TelemetryService();
 
-    private final Lazy<TelemetryMessageBuilder> builder = new Lazy<>(() -> new TelemetryMessageBuilder(TelemetryService.class.getClassLoader()));
+    private final Lazy<TelemetryMessageBuilder> builder = new Lazy<>(() ->
+        new TelemetryMessageBuilder(PluginManager.getPluginByClass(this.getClass()))
+    );
 
     public static TelemetryMessageBuilder instance() {
         return INSTANCE.builder.get();


### PR DESCRIPTION
bumps telemetry to 1.2.1 and fixes the deprecation message
![image](https://github.com/user-attachments/assets/c0b7c18b-c6fb-4490-9381-c58dda850459)
