### PR TITLE
fix: set platformOnly to false to collect all extensions in the wizard

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusExtensionsStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusExtensionsStep.java
@@ -147,7 +147,7 @@ public class QuarkusExtensionsStep extends ModuleWizardStep implements Disposabl
             panel.add(filter);
 
             JCheckBox platformCheckbox = new JCheckBox();
-            platformCheckbox.setSelected(true);
+            platformCheckbox.setSelected(false);
             platformCheckbox.setText("Platform only extensions");
             panel.add(platformCheckbox);
 


### PR DESCRIPTION
Unselect by default the platform checkbox to retrieve for instance langChain4j qurkus extensions:

![image](https://github.com/user-attachments/assets/64a88beb-3285-455d-8946-57cb14df9d7a)
