### PR TITLE
chore: use releases of LSP4MP 0.12.0 + Quarkus LS 0.19.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ version = prop("pluginVersion")
 
 val quarkusVersion = prop("quarkusVersion")
 val lsp4mpVersion = prop("lsp4mpVersion")
-val quarkusLsVersion = prop("lsp4mpVersion")
+val quarkusLsVersion = prop("quarkusLsVersion")
 val quteLsVersion = prop("quteLsVersion")
 // Configure project's dependencies
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,9 +18,9 @@ platformPlugins=com.intellij.java, maven, gradle-java, properties, yaml, com.red
 gradleVersion=8.6
 channel=nightly
 quarkusVersion=3.1.2.Final
-lsp4mpVersion=0.12.0-SNAPSHOT
-quarkusLsVersion=0.19.0-SNAPSHOT
-quteLsVersion=0.19.0-SNAPSHOT
+lsp4mpVersion=0.12.0
+quarkusLsVersion=0.19.0
+quteLsVersion=0.19.0
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html


### PR DESCRIPTION
chore: use releases of LSP4MP 0.12.0 + Quarkus LS 0.19.0