### PR TITLE
fix: prevent from duplicate Qute parameter key

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/template/datamodel/CheckedTemplateSupport.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/template/datamodel/CheckedTemplateSupport.java
@@ -291,7 +291,7 @@ public class CheckedTemplateSupport extends AbstractAnnotationTypeReferenceDataM
                     if (templateOrFragment.getParameter(parameter.getKey()) == null) {
                         // Add parameter if it doesn't exist
                         // to avoid parameters duplication
-                        templateOrFragment.getParameters().add(parameter);
+                        templateOrFragment.addParameter(parameter);
                     }
                 }
             }

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/template/datamodel/TemplateRecordsSupport.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/template/datamodel/TemplateRecordsSupport.java
@@ -98,7 +98,11 @@ public class TemplateRecordsSupport extends AbstractInterfaceImplementationDataM
             DataModelParameter parameter = new DataModelParameter();
             parameter.setKey(field.getName());
             parameter.setSourceType(PsiTypeUtils.resolveSignature(field.getType(), field.isVarArgs()));
-            template.getParameters().add(parameter);
+            if (template.getParameter(parameter.getKey()) == null) {
+                // Add parameter if it doesn't exist
+                // to avoid parameters duplication
+                template.addParameter(parameter);
+            }
         }
 
         // Collect data parameters for the given template


### PR DESCRIPTION
fix: prevent from duplicate Qute parameter key

Even if I can repoduce a problem like vscode-quarkus, I create this PR to be aligned with JDT code of the PR

https://github.com/redhat-developer/quarkus-ls/pull/988