### PR TITLE
fix: Bump intellij-common-ui-test-library version to 0.4.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,7 @@ dependencies {
         builtBy("copyDeps")
     })
 
-    testImplementation("com.redhat.devtools.intellij:intellij-common-ui-test-library:0.4.0")
+    testImplementation("com.redhat.devtools.intellij:intellij-common-ui-test-library:0.4.2")
 
     // And now for some serious HACK!!!
     // Starting with 2023.1, all gradle tests fail importing projects with a:


### PR DESCRIPTION
Older version of intellij-library does not support "platformType" and "platformVersion" properties.