### PR TITLE
fix: set languageId to have highlight with LSP4IJ 0.7.0

### DIFF
--- a/src/main/resources/META-INF/lsp4ij-quarkus.xml
+++ b/src/main/resources/META-INF/lsp4ij-quarkus.xml
@@ -18,8 +18,10 @@
         </server>
         <languageMapping language="Properties"
                          serverId="microprofile"
+                         languageId="microprofile-properties"
                          documentMatcher="com.redhat.devtools.intellij.quarkus.lsp.QuarkusDocumentMatcherForPropertiesFile"/>
         <languageMapping language="JAVA"
+                         languageId="java"
                          serverId="microprofile"
                          documentMatcher="com.redhat.devtools.intellij.quarkus.lsp.QuarkusDocumentMatcherForJavaFile"/>
     </extensions>


### PR DESCRIPTION
fix: set languageId to have highlight with LSP4IJ 0.7.0

LSP4IJ 0.7.0 will support documentSelector and  dynamic capabilities with PR https://github.com/redhat-developer/lsp4ij/pull/566

MicroProfile LS supports `textDocument/documentHighlight` with dynamic capability and set the documentSelector for the `microprofile-properties` languageId:

```json
[Trace - 20:07:06] Received request 'client/registerCapability - (9)'
Params: {
  "registrations": [
    {
      "id": "04793b8a-d455-49f8-8c45-d932f15a1714",
      "method": "textDocument/documentHighlight",
      "registerOptions": {
        "documentSelector": [
          {
            "language": "microprofile-properties"
          }
        ]
      }
    }
  ]
}
```

It means that  `textDocument/documentHighlight` LSP request must be only sent for "microprofile-properties" language and not for java files which works like this in vscode.

As LSP4IJ 0.7.0 will support "documentSelector", this PR associate the microprofile-config.properties to the "microprofile-properties" to enable highlight for this file. Without this languageId, we will loose highlight when LSP4IJ 0.7.0 will be released.

@aparnamichael @turkeylurkey @mrglavas please do the same think with your Liberty Tools.