### PR TITLE
fix: REST endpoint code vision hint is not resolving a public static final and quarkus.rest.path parameter

### DIFF
--- a/projects/lsp4mp/projects/maven/hibernate-orm-resteasy-yaml/src/main/java/org/acme/hibernate/orm/FruitResource.java
+++ b/projects/lsp4mp/projects/maven/hibernate-orm-resteasy-yaml/src/main/java/org/acme/hibernate/orm/FruitResource.java
@@ -75,19 +75,27 @@ public class FruitResource {
     }
 
     @DELETE
+    @Path("{id}")
     @Transactional
-    @Path(
-        "{id}"
-        )
-    public
-    Response
-    delete(@PathParam Integer id) {
+    public Response delete(@PathParam Integer id) {
         Fruit entity = entityManager.getReference(Fruit.class, id);
         if (entity == null) {
             throw new WebApplicationException("Fruit with id of " + id + " does not exist.", 404);
         }
         entityManager.remove(entity);
         return Response.status(204).build();
+    }
+
+    private static final String PATH = "path_with_java_constant";
+
+    @GET
+    @Path(PATH)
+    public Fruit getSingle2(@PathParam Integer id) {
+        Fruit entity = entityManager.find(Fruit.class, id);
+        if (entity == null) {
+            throw new WebApplicationException("Fruit with id of " + id + " does not exist.", 404);
+        }
+        return entity;
     }
 
     @Provider

--- a/projects/lsp4mp/projects/maven/hibernate-orm-resteasy/src/main/java/org/acme/hibernate/orm/FruitResource.java
+++ b/projects/lsp4mp/projects/maven/hibernate-orm-resteasy/src/main/java/org/acme/hibernate/orm/FruitResource.java
@@ -75,19 +75,27 @@ public class FruitResource {
     }
 
     @DELETE
+    @Path("{id}")
     @Transactional
-    @Path(
-        "{id}"
-        )
-    public
-    Response
-    delete(@PathParam Integer id) {
+    public Response delete(@PathParam Integer id) {
         Fruit entity = entityManager.getReference(Fruit.class, id);
         if (entity == null) {
             throw new WebApplicationException("Fruit with id of " + id + " does not exist.", 404);
         }
         entityManager.remove(entity);
         return Response.status(204).build();
+    }
+
+    private static final String PATH = "path_with_java_constant";
+
+    @GET
+    @Path(PATH)
+    public Fruit getSingle2(@PathParam Integer id) {
+        Fruit entity = entityManager.find(Fruit.class, id);
+        if (entity == null) {
+            throw new WebApplicationException("Fruit with id of " + id + " does not exist.", 404);
+        }
+        return entity;
     }
 
     @Provider

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/jaxrs/JaxRsContext.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/jaxrs/JaxRsContext.java
@@ -111,6 +111,7 @@ public class JaxRsContext {
 	 */
 	public void setApplicationPath(String applicationPath) {
 		this.applicationPath = applicationPath;
+		this.applicationPathLoaded = applicationPath != null;
 	}
 
 	public static JaxRsContext getJaxRsContext(JavaCodeLensContext context) {

--- a/src/main/java/com/redhat/microprofile/psi/internal/quarkus/jaxrs/java/QuarkusJaxRsCodeLensParticipant.java
+++ b/src/main/java/com/redhat/microprofile/psi/internal/quarkus/jaxrs/java/QuarkusJaxRsCodeLensParticipant.java
@@ -36,6 +36,8 @@ public class QuarkusJaxRsCodeLensParticipant implements IJavaCodeLensParticipant
 	private static final String QUARKUS_HTTP_PORT = "quarkus.http.port";
 	private static final String QUARKUS_DEV_HTTP_ROOT_PATH = "%dev.quarkus.http.root-path";
 	private static final String QUARKUS_HTTP_ROOT_PATH = "quarkus.http.root-path";
+	private static final String QUARKUS_REST_PATH = "quarkus.rest.path";
+	private static final String QUARKUS_DEV_REST_PATH = "%dev.quarkus.rest.path";
 
 	@Override
 	public void beginCodeLens(JavaCodeLensContext context, ProgressIndicator monitor) {
@@ -49,9 +51,16 @@ public class QuarkusJaxRsCodeLensParticipant implements IJavaCodeLensParticipant
 		JaxRsContext.getJaxRsContext(context).setServerPort(devServerPort);
 
 		// Retrieve HTTP root path from application.properties
+		// quarkus.http.root-path
 		String httpRootPath = mpProject.getProperty(QUARKUS_HTTP_ROOT_PATH);
 		String devHttpRootPath = mpProject.getProperty(QUARKUS_DEV_HTTP_ROOT_PATH, httpRootPath);
 		JaxRsContext.getJaxRsContext(context).setRootPath(devHttpRootPath);
+
+		// quarkus.rest.path
+		// see https://quarkus.io/guides/rest#declaring-endpoints-uri-mapping
+		String restPath = mpProject.getProperty(QUARKUS_REST_PATH);
+		String devRestPath = mpProject.getProperty(QUARKUS_DEV_REST_PATH, restPath);
+		JaxRsContext.getJaxRsContext(context).setApplicationPath(devRestPath);
 	}
 
 	@Override

--- a/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/jaxrs/java/JaxRsCodeLensTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/jaxrs/java/JaxRsCodeLensTest.java
@@ -66,7 +66,8 @@ public class JaxRsCodeLensTest extends LSP4MPMavenModuleImportingTestCase {
                 cl("http://localhost:" + port + rootPath + "/fruits/{id}", "", r(38, 4, 4)), //
                 cl("http://localhost:" + port + rootPath + "/fruits", "", r(48, 4, 4)), //
                 cl("http://localhost:" + port + rootPath + "/fruits/{id}", "", r(60, 4, 4)), //
-                cl("http://localhost:" + port + rootPath + "/fruits/{id}", "", r(81, 4, 4)));
+                cl("http://localhost:" + port + rootPath + "/fruits/{id}", "", r(79, 4, 4)), //
+                cl("http://localhost:" + port + rootPath + "/fruits/path_with_java_constant", "", r(92, 4, 4)));
     }
 
 }


### PR DESCRIPTION
fix: REST endpoint code vision hint is not resolving a public static final and quarkus.rest.path parameter

Fixes #1393

* fix: for:  REST endpoint code vision hint is not resolving a public static final

![image](https://github.com/user-attachments/assets/2fc5fc58-b2bc-416e-866e-e0bf15cea423)

 * fix for quarkus.rest.path

With `quarkus.rest.path=bar` in `application.properties`:

![image](https://github.com/user-attachments/assets/948e623b-5daf-410d-82d6-71cc8c24826e)
