### PR TITLE
fix: remove ConfigPhase.BOOTSRAP which has been removed from Quarkus.

### DIFF
--- a/src/main/java/com/redhat/microprofile/psi/internal/quarkus/core/properties/QuarkusConfigRootProvider.java
+++ b/src/main/java/com/redhat/microprofile/psi/internal/quarkus/core/properties/QuarkusConfigRootProvider.java
@@ -197,10 +197,6 @@ public class QuarkusConfigRootProvider extends AbstractAnnotationTypeReferencePr
 									"Run", "Time", "Config"),
 							"Configuration"),
 					"Config");
-		} else if (configPhase == ConfigPhase.BOOTSTRAP) {
-			trimmedSegments = withoutSuffix(withoutSuffix(
-					withoutSuffix(withoutSuffix(segments, "Bootstrap", "Configuration"), "Bootstrap", "Config"),
-					"Configuration"), "Config");
 		} else {
 			trimmedSegments = withoutSuffix(withoutSuffix(
 					withoutSuffix(withoutSuffix(segments, "Build", "Time", "Configuration"), "Build", "Time", "Config"),


### PR DESCRIPTION
fix: remove ConfigPhase.BOOTSRAP which has been removed from Quarkus.