### PR TITLE
fix: remove diagnostic of missing property for Optional fields

### DIFF
--- a/projects/lsp4mp/projects/maven/config-quickstart/src/main/java/org/acme/config/DefaultValueResource.java
+++ b/projects/lsp4mp/projects/maven/config-quickstart/src/main/java/org/acme/config/DefaultValueResource.java
@@ -35,4 +35,16 @@ public class DefaultValueResource {
 
     @ConfigProperty(name = "greeting10", defaultValue="AB")
     char greeting10;
+
+    @ConfigProperty(name = "greeting.optional") // this optional properties are not set
+    java.util.Optional<String> optional;
+
+    @ConfigProperty(name = "greeting.optional.int")
+    java.util.OptionalInt optional;
+
+    @ConfigProperty(name = "greeting.optional.long")
+    java.util.OptionalLong optional;
+
+    @ConfigProperty(name = "greeting.optional.double")
+    java.util.OptionalDouble optional;
 }

--- a/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/config/properties/ConfigItemIntBoolDefaultValueTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/config/properties/ConfigItemIntBoolDefaultValueTest.java
@@ -49,7 +49,8 @@ public class ConfigItemIntBoolDefaultValueTest extends LSP4MPMavenModuleImportin
         assertProperties(infoFromClasspath,
                 259 + 31 /* properties from Java sources with ConfigProperty */ + //
                         7 /* static properties from microprofile-context-propagation-api */ +
-                        1 /* static property from microprofile config_ordinal */,
+                        1 /* static property from microprofile config_ordinal */ +
+                        4 /* optional properties */,
 
                 // GreetingConstructorResource(
                 // 		@ConfigProperty(name = "greeting.constructor.message") String message,

--- a/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/config/properties/MicroProfileConfigPropertyTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/config/properties/MicroProfileConfigPropertyTest.java
@@ -45,7 +45,8 @@ public class MicroProfileConfigPropertyTest extends LSP4MPMavenModuleImportingTe
                         31 /* properties from Java sources with ConfigProperty */ + //
                         2 /* properties from Java sources with ConfigRoot */ + //
                         7 /* static properties from microprofile-context-propagation-api */ +
-                        1 /* static property from microprofile config_ordinal */,
+                        1 /* static property from microprofile config_ordinal */ +
+                        4 /* optional properties */,
 
                 // io.quarkus.deployment.ApplicationConfig
                 p("quarkus-core", "quarkus.application.name", "java.util.Optional<java.lang.String>",
@@ -120,7 +121,8 @@ public class MicroProfileConfigPropertyTest extends LSP4MPMavenModuleImportingTe
         MicroProfileProjectInfo infoFromJavaSources = PropertiesManager.getInstance().getMicroProfileProjectInfo(module, MicroProfilePropertiesScope.ONLY_SOURCES, ClasspathKind.SRC, PsiUtilsLSImpl.getInstance(myProject), DocumentFormat.PlainText, new EmptyProgressIndicator());
 
         assertProperties(infoFromJavaSources, 31 /* properties from Java sources with ConfigProperty */ + //
-                        2 /* properties from Java sources with ConfigRoot */,
+                        2 /* properties from Java sources with ConfigRoot */ +
+                        4 /* optional properties */,
 
                 // GreetingResource
                 // @ConfigProperty(name = "greeting.message")


### PR DESCRIPTION
this PR removes the diagnostic of missing property for `java.util.Optional` fields (and other optional containers as defined in [config-reference](https://quarkus.io/guides/config-reference#default-values) ), as this properties may not be set