### PR TITLE
fix: Modification to replace the usage of deprecated method DumbService.runReadActionInSmartMode(Computable)

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (c) 2019-2020 Red Hat Inc. and others.
+* Copyright (c) 2019-2025 Red Hat Inc. and others.
 * All rights reserved. This program and the accompanying materials
 * which accompanies this distribution, and is available at
 * https://www.eclipse.org/legal/epl-v20.html
@@ -11,13 +11,10 @@
 *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core;
 
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
-import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
-import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
@@ -97,7 +94,7 @@ public class ProjectLabelManager {
 			if (module == null) {
 				return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
 			}
-			return DumbService.getInstance(module.getProject()).runReadActionInSmartMode(() -> getProjectLabelInfo(module, params.getTypes(), utils));
+			return getProjectLabelInfo(module, params.getTypes(), utils);
 		} catch (IOException e) {
 			return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
 		}

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Red Hat, Inc.
+ * Copyright (c) 2019-2025 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -10,12 +10,10 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core;
 
-import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.progress.EmptyProgressIndicator;
 import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.project.DumbService;
-import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiFile;
@@ -222,7 +220,8 @@ public class PropertiesManager {
     }
 
     public Location findPropertyLocation(Module module, String sourceType, String sourceField, String sourceMethod, IPsiUtils utils) {
-        return DumbService.getInstance(module.getProject()).runReadActionInSmartMode(() -> {
+        Project project = module.getProject();
+        return ReadAction.nonBlocking(() -> {
             PsiMember fieldOrMethod = findDeclaredProperty(module, sourceType, sourceField, sourceMethod, utils);
             if (fieldOrMethod != null) {
                 PsiFile classFile = fieldOrMethod.getContainingFile();
@@ -235,7 +234,7 @@ public class PropertiesManager {
                 return utils.toLocation(fieldOrMethod);
             }
             return null;
-        });
+        }).inSmartMode(project).executeSynchronously();
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/PropertiesManager.java
@@ -10,10 +10,8 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core;
 
-import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiFile;
@@ -220,21 +218,18 @@ public class PropertiesManager {
     }
 
     public Location findPropertyLocation(Module module, String sourceType, String sourceField, String sourceMethod, IPsiUtils utils) {
-        Project project = module.getProject();
-        return ReadAction.nonBlocking(() -> {
-            PsiMember fieldOrMethod = findDeclaredProperty(module, sourceType, sourceField, sourceMethod, utils);
-            if (fieldOrMethod != null) {
-                PsiFile classFile = fieldOrMethod.getContainingFile();
-                if (classFile != null) {
-                    // Try to download source if required
-                    if (utils != null) {
-                        utils.discoverSource(classFile);
-                    }
+        PsiMember fieldOrMethod = findDeclaredProperty(module, sourceType, sourceField, sourceMethod, utils);
+        if (fieldOrMethod != null) {
+            PsiFile classFile = fieldOrMethod.getContainingFile();
+            if (classFile != null) {
+                // Try to download source if required
+                if (utils != null) {
+                    utils.discoverSource(classFile);
                 }
-                return utils.toLocation(fieldOrMethod);
             }
-            return null;
-        }).inSmartMode(project).executeSynchronously();
+            return utils.toLocation(fieldOrMethod);
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/PropertiesManagerForJava.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Red Hat, Inc.
+ * Copyright (c) 2020-2025 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v2.0 which accompanies this distribution,
@@ -11,14 +11,10 @@
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core;
 
 import com.intellij.lang.jvm.JvmParameter;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.progress.ProgressIndicator;
-import com.intellij.openapi.project.DumbService;
-import com.intellij.openapi.util.Computable;
-import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiTreeUtil;


### PR DESCRIPTION
- Replaced deprecated method `DumbService.runReadActionInSmartMode(Computable)`
- Removed unused DumbService and other imports in related files
- Changed copyright year to 2025

Fixes #1420 
