### PR TITLE
fix: Deprecated constructor 'URL.<init>(String)' changed to URI.toURL 

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/jaxrs/java/JaxRsWorkspaceSymbolParticipant.java
@@ -28,6 +28,8 @@ import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -112,7 +114,12 @@ public class JaxRsWorkspaceSymbolParticipant implements IJavaWorkspaceSymbolsPar
 		Location location = new Location(methodInfo.getDocumentUri(), r);
 
 		StringBuilder nameBuilder = new StringBuilder("@");
-		URL url = new URL(methodInfo.getUrl());
+		URL url;
+		try {
+			url = new URI(methodInfo.getUrl()).toURL();
+		} catch (URISyntaxException e) {
+			throw new RuntimeException(e);
+		}
 		String path = url.getPath();
 		nameBuilder.append(path);
 		nameBuilder.append(": ");


### PR DESCRIPTION
Fixes #1427 