### PR TITLE
feat: define a custom LSP local inspection tool for Qute

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteClientFeatures.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteClientFeatures.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.qute.lsp;
+
+import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
+
+/**
+ * Qute client features.
+ */
+public class QuteClientFeatures extends LSPClientFeatures {
+
+    public QuteClientFeatures() {
+        super.setDiagnosticFeature(new QuteDiagnosticFeature());
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteDiagnosticFeature.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteDiagnosticFeature.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.qute.lsp;
+
+import com.intellij.codeInspection.LocalInspectionTool;
+import com.intellij.psi.PsiFile;
+import com.redhat.devtools.intellij.qute.lang.QuteLanguage;
+import com.redhat.devtools.intellij.qute.psi.core.inspections.QuteLSPLocalInspectionTool;
+import com.redhat.devtools.lsp4ij.client.features.LSPDiagnosticFeature;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Qute diagnostics features.
+ */
+public class QuteDiagnosticFeature extends LSPDiagnosticFeature {
+
+    @Override
+    public boolean isInspectionApplicableFor(@NotNull PsiFile file,
+                                             @NotNull LocalInspectionTool inspection) {
+        if (file.getLanguage() == QuteLanguage.INSTANCE) {
+            // Show Qute templates warnings/errors
+            // after clicking on "Inspect Code..." from the problem view.
+            return QuteLSPLocalInspectionTool.ID.equals(inspection.getID());
+        }
+        return super.isInspectionApplicableFor(file, inspection);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteLanguageServerFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteLanguageServerFactory.java
@@ -13,9 +13,11 @@ package com.redhat.devtools.intellij.qute.lsp;
 import com.intellij.openapi.project.Project;
 import com.redhat.devtools.lsp4ij.LanguageServerFactory;
 import com.redhat.devtools.lsp4ij.client.LanguageClientImpl;
+import com.redhat.devtools.lsp4ij.client.features.LSPClientFeatures;
 import com.redhat.devtools.lsp4ij.server.StreamConnectionProvider;
 import com.redhat.qute.ls.api.QuteLanguageServerAPI;
 import org.eclipse.lsp4j.services.LanguageServer;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Qute language server factory.
@@ -23,17 +25,22 @@ import org.eclipse.lsp4j.services.LanguageServer;
 public class QuteLanguageServerFactory implements LanguageServerFactory {
 
     @Override
-    public StreamConnectionProvider createConnectionProvider(Project project) {
+    public @NotNull StreamConnectionProvider createConnectionProvider(@NotNull Project project) {
         return new QuteServer(project);
     }
 
     @Override
-    public LanguageClientImpl createLanguageClient(Project project) {
+    public @NotNull LanguageClientImpl createLanguageClient(@NotNull Project project) {
         return new QuteLanguageClient(project);
     }
 
     @Override
-    public Class<? extends LanguageServer> getServerInterface() {
+    public @NotNull Class<? extends LanguageServer> getServerInterface() {
         return QuteLanguageServerAPI.class;
+    }
+
+    @Override
+    public @NotNull LSPClientFeatures createClientFeatures() {
+        return new QuteClientFeatures();
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/core/inspections/QuteLSPLocalInspectionTool.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/core/inspections/QuteLSPLocalInspectionTool.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.qute.psi.core.inspections;
+
+import com.redhat.devtools.lsp4ij.inspections.LSPLocalInspectionToolBase;
+
+/**
+ * Custom LSP inspection tool for Qute to display
+ * Qute templates warnings/errors in Qute/Templates tree node
+ * from the problem view (after clicking on "Inspect Code..." ).
+ */
+public class QuteLSPLocalInspectionTool extends LSPLocalInspectionToolBase {
+
+    public static final String ID = "QuteLSPLocalInspectionTool";
+}

--- a/src/main/resources/META-INF/lsp4ij-qute.xml
+++ b/src/main/resources/META-INF/lsp4ij-qute.xml
@@ -56,6 +56,15 @@
                              instance="com.redhat.devtools.intellij.qute.settings.QuteConfigurable"/>
 
         <localInspection
+                id="QuteLSPLocalInspectionTool"
+                language="Qute_"
+                bundle="messages.QuteBundle"
+                groupName="Qute"
+                displayName="Templates"
+                enabledByDefault="true"
+                implementationClass="com.redhat.devtools.intellij.qute.psi.core.inspections.QuteLSPLocalInspectionTool"/>
+
+        <localInspection
                 unfair="true"
                 language="Qute_"
                 bundle="messages.QuteBundle"


### PR DESCRIPTION
feat: define a custom LSP local inspection tool for Qute

This PR provides the capability to display all Qute errors of all Projetc by executing "`Inspect Code...`" from the Problem view:

![image](https://github.com/user-attachments/assets/b5b31732-2b05-4ad9-9b10-c46a890e0b5b)

Here the result with quarkus-roq:

![image](https://github.com/user-attachments/assets/3af8243c-97ed-4d16-aafc-5f657ed15bc4)

//cc @ia3andy 