### PR TITLE
fix: Get project labels from a given project

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/ProjectLabelManager.java
@@ -1,25 +1,25 @@
 /*******************************************************************************
-* Copyright (c) 2019-2025 Red Hat Inc. and others.
-* All rights reserved. This program and the accompanying materials
-* which accompanies this distribution, and is available at
-* https://www.eclipse.org/legal/epl-v20.html
-*
-* SPDX-License-Identifier: EPL-2.0
-* 
-* Contributors:
-*     Red Hat Inc. - initial API and implementation
-*******************************************************************************/
+ * Copyright (c) 2019-2025 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
 package com.redhat.devtools.intellij.lsp4mp4ij.psi.core;
 
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.IPsiUtils;
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.eclipse.lsp4mp.commons.MicroProfileJavaProjectLabelsParams;
 import org.eclipse.lsp4mp.commons.ProjectLabelInfoEntry;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,103 +30,101 @@ import java.util.List;
  * project labels for all projects in the workspace
  *
  * @see <a ref="https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/ProjectLabelManager.java">https://github.com/redhat-developer/quarkus-ls/blob/master/microprofile.jdt/com.redhat.microprofile.jdt.core/src/main/java/com/redhat/microprofile/jdt/core/ProjectLabelManager.java</a>
- *
  */
 public class ProjectLabelManager {
-	private static final ProjectLabelManager INSTANCE = new ProjectLabelManager();
 
-	public static ProjectLabelManager getInstance() {
-		return INSTANCE;
-	}
+    private final @NotNull Project project;
 
-	private ProjectLabelManager() {
+    public static ProjectLabelManager getInstance(@NotNull Project project) {
+        return project.getService(ProjectLabelManager.class);
+    }
 
-	}
+    private ProjectLabelManager(@NotNull Project project) {
+        this.project = project;
+    }
 
-	/**
-	 * Returns project label results for all projects in the workspace
-	 *
-	 * @return project label results for all projects in the workspace
-	 */
-	public List<ProjectLabelInfoEntry> getProjectLabelInfo(IPsiUtils utils) {
-		List<ProjectLabelInfoEntry> results = new ArrayList<>();
-		for(Project project : ProjectManager.getInstance().getOpenProjects()) {
-			for(Module module : ModuleManager.getInstance(project).getModules()) {
-				ProjectLabelInfoEntry info = getProjectLabelInfo(module, null, utils);
-				if (info != null) {
-					results.add(info);
-				}
-			}
-		}
-		return results;
-	}
+    /**
+     * Returns project label results for all projects in the workspace
+     *
+     * @return project label results for all projects in the workspace
+     */
+    public List<ProjectLabelInfoEntry> getProjectLabelInfo(IPsiUtils utils) {
+        List<ProjectLabelInfoEntry> results = new ArrayList<>();
+        for (Module module : ModuleManager.getInstance(project).getModules()) {
+            ProjectLabelInfoEntry info = getProjectLabelInfo(module, null, utils);
+            if (info != null) {
+                results.add(info);
+            }
+        }
+        return results;
+    }
 
-	/**
-	 * Returns project label results for the given Eclipse project.
-	 *
-	 * @param project Eclipse project.
-	 * @param types   the Java type list to check.
-	 * @return project label results for the given Eclipse project.
-	 */
-	private ProjectLabelInfoEntry getProjectLabelInfo(Module project, List<String> types, IPsiUtils utils) {
-		String uri = PsiUtilsLSImpl.getProjectURI(project);
-		if (uri != null) {
-			return new ProjectLabelInfoEntry(uri, project.getName(), getProjectLabels(project, types, utils));
-		}
-		return null;
-	}
+    /**
+     * Returns project label results for the given Eclipse project.
+     *
+     * @param project Eclipse project.
+     * @param types   the Java type list to check.
+     * @return project label results for the given Eclipse project.
+     */
+    private ProjectLabelInfoEntry getProjectLabelInfo(Module project, List<String> types, IPsiUtils utils) {
+        String uri = PsiUtilsLSImpl.getProjectURI(project);
+        if (uri != null) {
+            return new ProjectLabelInfoEntry(uri, project.getName(), getProjectLabels(project, types, utils));
+        }
+        return null;
+    }
 
-	/**
-	 * Returns project label results for the given Java file uri parameter.
-	 * 
-	 * @param params  the Java file uri parameter.
-	 * @param utils   the JDT utilities.
-	 * @return project label results for the given Java file uri parameter.
-	 */
-	public ProjectLabelInfoEntry getProjectLabelInfo(MicroProfileJavaProjectLabelsParams params, IPsiUtils utils) {
-		try {
-			VirtualFile file = utils.findFile(params.getUri());
-			if (file == null) {
-				// The uri doesn't belong to an IDEA project
-				return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
-			}
-			Module module = utils.getModule(file);
-			if (module == null) {
-				return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
-			}
-			return getProjectLabelInfo(module, params.getTypes(), utils);
-		} catch (IOException e) {
-			return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
-		}
-	}
+    /**
+     * Returns project label results for the given Java file uri parameter.
+     *
+     * @param params the Java file uri parameter.
+     * @param utils  the JDT utilities.
+     * @return project label results for the given Java file uri parameter.
+     */
+    public ProjectLabelInfoEntry getProjectLabelInfo(MicroProfileJavaProjectLabelsParams params, IPsiUtils utils) {
+        try {
+            VirtualFile file = utils.findFile(params.getUri());
+            if (file == null) {
+                // The uri doesn't belong to an IDEA project
+                return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
+            }
+            Module module = utils.getModule(file);
+            if (module == null) {
+                return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
+            }
+            return getProjectLabelInfo(module, params.getTypes(), utils);
+        } catch (IOException e) {
+            return ProjectLabelInfoEntry.EMPTY_PROJECT_INFO;
+        }
+    }
 
-	/**
-	 * Returns the project labels for the given project.
-	 * 
-	 * @param project the Eclipse project.
-	 * @param types   the Java type list to check.
-	 * @return the project labels for the given project.
-	 */
-	private List<String> getProjectLabels(Module project, List<String> types, IPsiUtils utils) {
-		// Update labels by using the
-		// "com.redhat.microprofile.jdt.core.projectLabelProviders" extension point (ex
-		// : "maven", "gradle", "quarkus", "microprofile").
-		List<String> projectLabels = new ArrayList<>();
-		List<IProjectLabelProvider> definitions = IProjectLabelProvider.EP_NAME.getExtensionList();
-		for (IProjectLabelProvider definition : definitions) {
-			projectLabels.addAll(definition.getProjectLabels(project));
-		}
-		// Update labels by checking if some Java types are in the classpath of the Java
-		// project.
-		if (types != null) {
-			for (String type : types) {
-				if (utils.findClass(project, type) != null) {
-					projectLabels.add(type);
-				}
-			}
-		}
+    /**
+     * Returns the project labels for the given project.
+     *
+     * @param project the Eclipse project.
+     * @param types   the Java type list to check.
+     * @return the project labels for the given project.
+     */
+    private List<String> getProjectLabels(Module project, List<String> types, IPsiUtils utils) {
+        // Update labels by using the
+        // "com.redhat.microprofile.jdt.core.projectLabelProviders" extension point (ex
+        // : "maven", "gradle", "quarkus", "microprofile").
+        List<String> projectLabels = new ArrayList<>();
+        List<IProjectLabelProvider> definitions = IProjectLabelProvider.EP_NAME.getExtensionList();
+        for (IProjectLabelProvider definition : definitions) {
+            projectLabels.addAll(definition.getProjectLabels(project));
+        }
+        // Update labels by checking if some Java types are in the classpath of the Java
+        // project.
+        if (types != null) {
+            for (String type : types) {
+                if (utils.findClass(project, type) != null) {
+                    projectLabels.add(type);
+                }
+            }
+        }
 
-		return projectLabels;
-	}
+        return projectLabels;
+    }
 
 }

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusLanguageClient.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusLanguageClient.java
@@ -207,13 +207,13 @@ public class QuarkusLanguageClient extends IndexAwareLanguageClient implements M
     @Override
     public CompletableFuture<ProjectLabelInfoEntry> getJavaProjectLabels(MicroProfileJavaProjectLabelsParams javaParams) {
         var coalesceBy = new CoalesceByKey("microprofile/java/projectLabels", javaParams.getUri(), javaParams.getTypes());
-        return runAsBackground("Computing Java projects labels", monitor -> ProjectLabelManager.getInstance().getProjectLabelInfo(javaParams, PsiUtilsLSImpl.getInstance(getProject())), coalesceBy);
+        return runAsBackground("Computing Java projects labels", monitor -> ProjectLabelManager.getInstance(getProject()).getProjectLabelInfo(javaParams, PsiUtilsLSImpl.getInstance(getProject())), coalesceBy);
     }
 
     @Override
     public CompletableFuture<List<ProjectLabelInfoEntry>> getAllJavaProjectLabels() {
         var coalesceBy = new CoalesceByKey("microprofile/java/workspaceLabels");
-        return runAsBackground("Computing All Java projects labels", monitor -> ProjectLabelManager.getInstance().getProjectLabelInfo(PsiUtilsLSImpl.getInstance(getProject())), coalesceBy);
+        return runAsBackground("Computing All Java projects labels", monitor -> ProjectLabelManager.getInstance(getProject()).getProjectLabelInfo(PsiUtilsLSImpl.getInstance(getProject())), coalesceBy);
     }
 
     @Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -414,7 +414,6 @@
         <!-- Telemetry manager singleton -->
         <applicationService
                 serviceImplementation="com.redhat.devtools.intellij.quarkus.telemetry.TelemetryManager"/>
-
         <facetType implementation="com.redhat.devtools.intellij.quarkus.facet.QuarkusFacetType"/>
         <framework.detector implementation="com.redhat.devtools.intellij.quarkus.facet.QuarkusFrameworkDetector"/>
         <moduleBuilder builderClass="com.redhat.devtools.intellij.quarkus.projectWizard.QuarkusModuleBuilder"/>
@@ -426,6 +425,8 @@
 
         <properties.implicitPropertyUsageProvider
                 implementation="com.redhat.devtools.intellij.quarkus.lang.QuarkusImplicitPropertyUsageProvider"/>
+        <projectService
+                serviceImplementation="com.redhat.devtools.intellij.lsp4mp4ij.psi.core.ProjectLabelManager"/>
         <projectService
                 serviceImplementation="com.redhat.devtools.intellij.lsp4mp4ij.classpath.ClasspathResourceChangedManager"/>
         <projectService

--- a/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/GradleProjectLabelTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/GradleProjectLabelTest.java
@@ -46,7 +46,7 @@ public class GradleProjectLabelTest extends GradleTestCase {
         VirtualFile javaFile = LocalFileSystem.getInstance().refreshAndFindFileByPath(ModuleUtilCore.getModuleDirPath(module) + "/src/main/java/org/acme/vertx/GreetingService.java");
         String uri = VfsUtilCore.virtualToIoFile(javaFile).toURI().toString();
         projectLabelsParams.setUri(uri);
-        ProjectLabelInfoEntry projectLabelEntry = ProjectLabelManager.getInstance().getProjectLabelInfo(projectLabelsParams, PsiUtilsLSImpl.getInstance(module.getProject()));
+        ProjectLabelInfoEntry projectLabelEntry = ProjectLabelManager.getInstance(module.getProject()).getProjectLabelInfo(projectLabelsParams, PsiUtilsLSImpl.getInstance(module.getProject()));
         assertLabels(projectLabelEntry, "quarkus", "microprofile");
     }
 

--- a/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/ProjectLabelTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/core/ProjectLabelTest.java
@@ -15,7 +15,6 @@ import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.utils.PsiMicroProfileUtil
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.core.ls.PsiUtilsLSImpl;
 import org.eclipse.lsp4mp.commons.ProjectLabelInfoEntry;
 import org.junit.Assert;
-import org.junit.Test;
 
 import java.io.File;
 import java.util.Arrays;
@@ -30,10 +29,10 @@ import java.util.stream.Collectors;
  */
 public class ProjectLabelTest extends MavenModuleImportingTestCase {
 
-    @Test
-    public void testgetProjectLabelInfoOnlyMaven() throws Exception {
+    public void testGetProjectLabelInfoOnlyMaven() throws Exception {
         Module maven = createMavenModule(new File("projects/lsp4mp/projects/maven/empty-maven-project"));
-        List<ProjectLabelInfoEntry> projectLabelEntries = ProjectLabelManager.getInstance().getProjectLabelInfo(PsiUtilsLSImpl.getInstance(maven.getProject()));
+        var project = maven.getProject();
+        List<ProjectLabelInfoEntry> projectLabelEntries = ProjectLabelManager.getInstance(project).getProjectLabelInfo(PsiUtilsLSImpl.getInstance(project));
         assertProjectLabelInfoContainsProject(projectLabelEntries, maven);
         assertLabels(projectLabelEntries, maven, "maven");
     }
@@ -46,10 +45,10 @@ public class ProjectLabelTest extends MavenModuleImportingTestCase {
 		assertLabels(projectLabelEntries, gradle, "gradle");
 	}*/
 
-    @Test
-    public void testgetProjectLabelQuarkusMaven() throws Exception {
+    public void testGetProjectLabelQuarkusMaven() throws Exception {
         Module quarkusMaven = createMavenModule(new File("projects/lsp4mp/projects/maven/using-vertx"));
-        List<ProjectLabelInfoEntry> projectLabelEntries = ProjectLabelManager.getInstance().getProjectLabelInfo(PsiUtilsLSImpl.getInstance(quarkusMaven.getProject()));
+        var project = quarkusMaven.getProject();
+        List<ProjectLabelInfoEntry> projectLabelEntries = ProjectLabelManager.getInstance(project).getProjectLabelInfo(PsiUtilsLSImpl.getInstance(project));
         assertProjectLabelInfoContainsProject(projectLabelEntries, quarkusMaven);
         assertLabels(projectLabelEntries, quarkusMaven, "microprofile", "maven", "quarkus");
     }
@@ -79,31 +78,31 @@ public class ProjectLabelTest extends MavenModuleImportingTestCase {
 		assertLabels(projectLabelEntries, gradle, "gradle");
 	}*/
 
-    @Test
-    public void testprojectNameMaven() throws Exception {
+    public void testProjectNameMaven() throws Exception {
         List<Module> modules = createMavenModules(Arrays.asList(
                 new File("projects/lsp4mp/projects/maven/using-vertx"),
                 new File("projects/lsp4mp/projects/maven/empty-maven-project"),
                 new File("projects/lsp4mp/projects/maven/folder-name-different-maven")
         ));
         Module quarkusMaven = modules.stream().filter(m -> m.getName().equals("using-vertx")).findFirst().get();
+        var project = quarkusMaven.getProject();
         Module maven = modules.stream().filter(m -> m.getName().equals("empty-maven-project")).findFirst().get();
         Module folderNameDifferent = modules.stream().filter(m -> m.getName().equals("mostly.empty")).findFirst().get();
-        List<ProjectLabelInfoEntry> projectLabelEntries = ProjectLabelManager.getInstance().getProjectLabelInfo(PsiUtilsLSImpl.getInstance(quarkusMaven.getProject()));
+        List<ProjectLabelInfoEntry> projectLabelEntries = ProjectLabelManager.getInstance(project).getProjectLabelInfo(PsiUtilsLSImpl.getInstance(project));
         assertName(projectLabelEntries, quarkusMaven, "using-vertx");
         assertName(projectLabelEntries, maven, "empty-maven-project");
         assertName(projectLabelEntries, folderNameDifferent, "mostly.empty");
     }
 
-    @Test
-    public void testprojectNameSameFolderName() throws Exception {
+    public void testProjectNameSameFolderName() throws Exception {
         List<Module> modules = createMavenModules(Arrays.asList(
                 new File("projects/lsp4mp/projects/maven/empty-maven-project"),
                 new File("projects/lsp4mp/projects/maven/folder/empty-maven-project")
         ));
         Module empty1 = modules.stream().filter(m -> m.getName().equals("empty-maven-project")).findFirst().get();
+        var project = empty1.getProject();
         Module empty2 = modules.stream().filter(m -> m.getName().equals("other-empty-maven-project")).findFirst().get();
-        List<ProjectLabelInfoEntry> projectLabelEntries = ProjectLabelManager.getInstance().getProjectLabelInfo(PsiUtilsLSImpl.getInstance(empty1.getProject()));
+        List<ProjectLabelInfoEntry> projectLabelEntries = ProjectLabelManager.getInstance(project).getProjectLabelInfo(PsiUtilsLSImpl.getInstance(project));
         assertName(projectLabelEntries, empty1, "empty-maven-project");
         assertName(projectLabelEntries, empty2, "other-empty-maven-project");
     }
@@ -121,7 +120,7 @@ public class ProjectLabelTest extends MavenModuleImportingTestCase {
 
     private static void assertProjectLabelInfoContainsProject(List<ProjectLabelInfoEntry> projectLabelEntries,
                                                               Module... javaProjects) {
-        List<String> actualProjectPaths = projectLabelEntries.stream().map(e -> e.getUri())
+        List<String> actualProjectPaths = projectLabelEntries.stream().map(ProjectLabelInfoEntry::getUri)
                 .collect(Collectors.toList());
         for (Module javaProject : javaProjects) {
             assertContains(actualProjectPaths, PsiMicroProfileUtils.getProjectURI(javaProject));
@@ -134,7 +133,7 @@ public class ProjectLabelTest extends MavenModuleImportingTestCase {
         List<String> actualLabels = getLabelsFromProjectPath(projectLabelEntries, javaProjectPath);
         Assert.assertEquals(
                 "Test project labels size for '" + javaProjectPath + "' with labels ["
-                        + actualLabels.stream().collect(Collectors.joining(",")) + "]",
+                        + String.join(",", actualLabels) + "]",
                 expectedLabels.length, actualLabels.size());
         for (String expectedLabel : expectedLabels) {
             assertContains(actualLabels, expectedLabel);


### PR DESCRIPTION
While fixing a bug in LSP4IJ with workspace symbols, I have noticed that workspace symbols is queried for all opened project (search of JAX-RS method in Symbol tab (Ctrl+N) is done for all opened project  and not for the current project.

This behavior is bad:

 * for feature: you see JAX-RS methods coming from other opened project which is wrong.
 * for performance, worlspace symbols is triggered for all opened project.

After debugging IntelliJ Quarkus, I have noticed the problem comes from ProjectLabelManager which uses all opened project instead of using the current project.

This PR fixes those 2 problems (features + performance).

