### PR TITLE
feat: collect proper variable for hover with Qute debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ When editing `application.properties` files, you have access to:
 
 ## Requirements
 
-  * Intellij IDEA 2023.3 or more recent (we **try** to support the last 4 major IDEA releases)
+  * Intellij IDEA 2024.3 or more recent (we **try** to support the last 4 major IDEA releases)
   * Java JDK (or JRE) 17 or more recent
 
     ​    

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ pluginSinceBuild=233.11799
 #pluginUntilBuild=233.*
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IC
-platformVersion=2023.3
+platformVersion=2024.3
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformBundledPlugins=com.intellij.java, org.jetbrains.idea.maven, org.jetbrains.plugins.gradle, com.intellij.properties, org.jetbrains.plugins.yaml

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteASTFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteASTFactory.java
@@ -19,6 +19,7 @@ import com.intellij.psi.templateLanguages.OuterLanguageElementImpl;
 import com.intellij.psi.tree.IElementType;
 import com.redhat.devtools.intellij.qute.lang.psi.QuteToken;
 import com.redhat.devtools.intellij.qute.lang.psi.QuteElementTypes;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteTokenType;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -34,6 +35,18 @@ public class QuteASTFactory extends ASTFactory {
             return new OuterLanguageElementImpl(type, text);
         }
         // Qute content
+        if (type == QuteTokenType.QUTE_EXPRESSION_OBJECT_PART) {
+            return new QuteASTObjectPart(text);
+        }
+        if (type == QuteTokenType.QUTE_EXPRESSION_PROPERTY_PART) {
+            return new QuteASTPropertyPart(text);
+        }
+        if (type == QuteTokenType.QUTE_EXPRESSION_METHOD_PART) {
+            return new QuteASTMethodPart(text);
+        }
+        if (type == QuteTokenType.QUTE_EXPRESSION_INFIX_METHOD_PART) {
+            return new QuteASTInfixMethodPart(text);
+        }
         return new QuteToken(type, text);
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteASTInfixMethodPart.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteASTInfixMethodPart.java
@@ -1,0 +1,43 @@
+package com.redhat.devtools.intellij.qute.lang;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteTokenType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class QuteASTInfixMethodPart extends QuteASTPart {
+
+    public QuteASTInfixMethodPart(CharSequence text) {
+        super(QuteTokenType.QUTE_EXPRESSION_INFIX_METHOD_PART, text);
+    }
+
+    public @Nullable PsiElement getRootPart() {
+        PsiElement part = this;
+        if (isQuteType(super.getParent(), QuteTokenType.QUTE_EXPRESSION_INFIX_METHOD_PART)) {
+            part = super.getParent();
+        }
+        QuteASTObjectPart objectPart = findObjectPart(part);
+        if (objectPart != null) {
+            return objectPart.getRootPart();
+        }
+        return null;
+    }
+
+    @Override
+    protected @Nullable TextRange getTextRangeInExpression(@NotNull PsiElement root) {
+        var infixParameter = findInfixParameter(this);
+        if (infixParameter == null) {
+            return null;
+        }
+        return new TextRange(root.getTextRange().getStartOffset(), infixParameter.getTextRange().getEndOffset());
+    }
+
+    protected @Nullable PsiElement findInfixParameter(PsiElement part) {
+        var next = part.getNextSibling();
+        if (isQuteType(next, QuteTokenType.QUTE_EXPRESSION_WHITESPACE)) {
+            return next.getNextSibling();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteASTMethodPart.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteASTMethodPart.java
@@ -1,0 +1,55 @@
+package com.redhat.devtools.intellij.qute.lang;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.source.tree.CompositeElement;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteElementType;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteElementTypes;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteTokenType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class QuteASTMethodPart extends QuteASTPart {
+
+    public QuteASTMethodPart(CharSequence text) {
+        super(QuteTokenType.QUTE_EXPRESSION_METHOD_PART, text);
+    }
+
+    public @Nullable PsiElement getRootPart() {
+        PsiElement part = this;
+        if (isQuteType(super.getParent(), QuteTokenType.QUTE_EXPRESSION_METHOD_PART)) {
+            part = super.getParent();
+        }
+        QuteASTObjectPart objectPart = findObjectPart(part);
+        if (objectPart != null) {
+            return objectPart.getRootPart();
+        }
+        return null;
+    }
+
+    @Override
+    protected @Nullable TextRange getTextRangeInExpression(@NotNull PsiElement root) {
+        var closedBracket = findClosedBracket(this);
+        return new TextRange(root.getTextRange().getStartOffset(), closedBracket != null ? closedBracket.getTextRange().getEndOffset() :  super.getTextRange().getEndOffset());
+    }
+
+    protected @Nullable PsiElement findClosedBracket(PsiElement part) {
+        var next = part.getNextSibling();
+        if (!isQuteType(next, QuteTokenType.QUTE_EXPRESSION_OPEN_BRACKET)) {
+            return null;
+        }
+        int nbBrackets = 0;
+        while(next != null) {
+            if (isQuteType(next, QuteTokenType.QUTE_EXPRESSION_OPEN_BRACKET)) {
+                nbBrackets++;
+            } else  if (isQuteType(next, QuteTokenType.QUTE_EXPRESSION_CLOSE_BRACKET)) {
+                nbBrackets--;
+                if (nbBrackets == 0) {
+                    return next;
+                }
+            }
+            next = next.getNextSibling();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteASTObjectPart.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteASTObjectPart.java
@@ -1,0 +1,35 @@
+package com.redhat.devtools.intellij.qute.lang;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteElementType;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteElementTypes;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteToken;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteTokenType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class QuteASTObjectPart extends QuteASTPart {
+
+    public QuteASTObjectPart(CharSequence text) {
+        super(QuteTokenType.QUTE_EXPRESSION_OBJECT_PART, text);
+    }
+
+    public @Nullable PsiElement getRootPart() {
+        PsiElement part = this;
+        if (isQuteType(super.getParent(), QuteTokenType.QUTE_EXPRESSION_OBJECT_PART)) {
+            part = super.getParent();
+        }
+        var previous = part.getPrevSibling();
+        if (isQuteType(previous, QuteTokenType.QUTE_EXPRESSION_COLON_SPACE)) {
+            previous = previous.getPrevSibling();
+            if (isQuteType(previous, QuteTokenType.QUTE_EXPRESSION_NAMESPACE_PART)) {
+                // ex : uri:Todos
+                return previous;
+            }
+        }
+        // ex : task
+        return this;
+    }
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteASTPart.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteASTPart.java
@@ -1,0 +1,56 @@
+package com.redhat.devtools.intellij.qute.lang;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.source.tree.CompositeElement;
+import com.intellij.psi.tree.IElementType;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteToken;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteTokenType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class QuteASTPart extends QuteToken {
+
+    public QuteASTPart(@NotNull IElementType type, CharSequence text) {
+        super(type, text);
+    }
+
+    @Override
+    public @Nullable TextRange getTextRangeInExpression() {
+        var root = getRootPart();
+        if (root == null) {
+            return null;
+        }
+        if (root == this) {
+            return getTextRange();
+        }
+        return getTextRangeInExpression(root);
+    }
+
+    protected @Nullable TextRange getTextRangeInExpression(@NotNull PsiElement root) {
+        return new TextRange(root.getTextRange().getStartOffset(), super.getTextRange().getEndOffset());
+    }
+
+    protected @Nullable QuteASTObjectPart findObjectPart(PsiElement part) {
+        var previous = part.getPrevSibling();
+        while(previous != null) {
+            if (isQuteType(previous, QuteTokenType.QUTE_EXPRESSION_OBJECT_PART)) {
+                // ex : uri:Todos
+                QuteASTObjectPart objectPart = previous instanceof QuteASTObjectPart o ? o : null;
+                if (objectPart == null) {
+                    var node = previous.getNode();
+                    if (node instanceof CompositeElement) {
+                        var firstNode = node.getFirstChildNode();
+                        objectPart = firstNode instanceof QuteASTObjectPart o ? o : null;
+                    }
+                }
+                return objectPart;
+            } else {
+                previous = previous.getPrevSibling();
+            }
+        }
+        return null;
+    }
+
+    public abstract @Nullable PsiElement getRootPart();
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteASTPropertyPart.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteASTPropertyPart.java
@@ -1,0 +1,30 @@
+package com.redhat.devtools.intellij.qute.lang;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.source.tree.CompositeElement;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteToken;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteTokenType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class QuteASTPropertyPart extends QuteASTPart {
+
+    public QuteASTPropertyPart(CharSequence text) {
+        super(QuteTokenType.QUTE_EXPRESSION_PROPERTY_PART, text);
+    }
+
+    public @Nullable PsiElement getRootPart() {
+        PsiElement part = this;
+        if (isQuteType(super.getParent(), QuteTokenType.QUTE_EXPRESSION_PROPERTY_PART)) {
+            part = super.getParent();
+        }
+        QuteASTObjectPart objectPart = findObjectPart(part);
+        if (objectPart != null) {
+            return objectPart.getRootPart();
+        }
+        return null;
+    }
+
+
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/psi/QuteToken.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/psi/QuteToken.java
@@ -13,12 +13,15 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.qute.lang.psi;
 
+import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.HintedReferenceHost;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReference;
 import com.intellij.psi.PsiReferenceService;
 import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.psi.tree.IElementType;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Qute token.
@@ -40,8 +43,18 @@ public class QuteToken extends LeafPsiElement implements HintedReferenceHost {
         return new PsiReference[] {new QutePsiReference(getNode())};
     }
 
+    public @Nullable TextRange getTextRangeInExpression() {
+        return null;
+    }
+
     @Override
     public boolean shouldAskParentForReferences(PsiReferenceService.@NotNull Hints hints) {
         return false;
+    }
+
+
+    protected static boolean isQuteType(@Nullable PsiElement element,
+                                        @NotNull IElementType type) {
+        return element != null && element.getNode().getElementType() == type;
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/run/QuteDebugAdapterVariableSupport.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/run/QuteDebugAdapterVariableSupport.java
@@ -10,10 +10,25 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.qute.run;
 
+import com.intellij.extapi.psi.ASTWrapperPsiElement;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.impl.source.tree.CompositeElement;
+import com.redhat.devtools.intellij.qute.lang.QuteLanguage;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteElementType;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteElementTypes;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteToken;
+import com.redhat.devtools.intellij.qute.lang.psi.QuteTokenType;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.dap.client.variables.providers.DebugVariablePositionProvider;
 import com.redhat.devtools.lsp4ij.dap.client.variables.providers.HighlighterDebugVariablePositionProvider;
 import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterVariableSupport;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -27,4 +42,23 @@ public class QuteDebugAdapterVariableSupport extends DebugAdapterVariableSupport
     public @NotNull Collection<DebugVariablePositionProvider> getDebugVariablePositionProvider() {
         return Collections.singletonList(new QuteDebugVariablePositionProvider());
     }
+
+    @Override
+    protected @Nullable TextRange getTextRange(@NotNull Project project, @NotNull VirtualFile file, @NotNull Document document, int offset, boolean sideEffectsAllowed) {
+        PsiFile psiFile = LSPIJUtils.getPsiFile(file, project);
+        if (psiFile == null) {
+            return null;
+        }
+        var element = psiFile.findElementAt(offset);
+        if (element == null || !QuteLanguage.INSTANCE.equals(element.getLanguage())) {
+            return null;
+        }
+        if (element instanceof QuteToken quteToken) {
+            return quteToken.getTextRangeInExpression();
+        }
+        return null;
+    }
+
 }
+
+

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -415,6 +415,8 @@
     <depends optional="true" config-file="com.redhat.devtools.intellij.quarkus.maven.xml">org.jetbrains.idea.maven</depends>
     <depends optional="true" config-file="com.redhat.devtools.intellij.quarkus.gradle.xml">org.jetbrains.plugins.gradle</depends>
     <depends optional="true" config-file="com.redhat.devtools.intellij.quarkus.json.xml">com.intellij.modules.json</depends>
+    <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
+    <idea-version since-build="242.*"/>
 
     <extensions defaultExtensionNs="com.intellij">
         <postStartupActivity implementation="com.redhat.devtools.intellij.quarkus.QuarkusPostStartupActivity"/>


### PR DESCRIPTION
feat: collect proper variable for hover with Qute debugger

Here a demo:

![QuteDebugHover](https://github.com/user-attachments/assets/32a6d407-5212-43a8-9152-d0c9a774fba1)

It also support infix notation. In the following sample, substring is hovered:

<img width="814" height="212" alt="image" src="https://github.com/user-attachments/assets/410c0fdf-b354-4148-b7d9-b46d80b0b2d4" />
