### PR TITLE
fix: Quarkus stream version is ignored when project is created

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusModuleInfoStep.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/projectWizard/QuarkusModuleInfoStep.java
@@ -165,7 +165,7 @@ public class QuarkusModuleInfoStep extends ModuleWizardStep implements Disposabl
             @Override
             public void contentsChanged(ListDataEvent e) {
                 updateJavaVersions();
-                loadExtensionsModel(streamModel, indicator);
+                extensionsModelRequest = loadExtensionsModel(streamModel, indicator);
             }
         });
 


### PR DESCRIPTION
fix: Quarkus stream version is ignored when project is created