### PR TITLE
fix: Avoid using IElementType#getDebugName() internal method

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/qute/run/QuteDebugAdapterVariableSupport.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/run/QuteDebugAdapterVariableSupport.java
@@ -33,12 +33,12 @@ import java.util.Collections;
  */
 public class QuteDebugAdapterVariableSupport extends DebugAdapterVariableSupport {
 
-    public static final String QUTE_JETBRAINS_IDENTIFIER = "IDENTIFIER";
-    public static final String QUTE_JETBRAINS_IDENTIFIER_EXPR = "IDENTIFIER_EXPR";
-    public static final String QUTE_JETBRAINS_REFERENCE_EXPR = "REFERENCE_EXPR";
-    public static final String QUTE_JETBRAINS_NAMESPACE_EXPR = "NAMESPACE_EXPR";
-    public static final String QUTE_JETBRAINS_QUALIFIER = "QUALIFIER";
-    public static final String QUTE_JETBRAINS_CALL_EXPR = "CALL_EXPR";
+    public static final String QUTE_JETBRAINS_IDENTIFIER = "QuteTokenType.IDENTIFIER";
+    private static final String QUTE_JETBRAINS_IDENTIFIER_EXPR = "QuteElementType.IDENTIFIER_EXPR";
+    private static final String QUTE_JETBRAINS_REFERENCE_EXPR = "QuteElementType.REFERENCE_EXPR";
+    private static final String QUTE_JETBRAINS_NAMESPACE_EXPR = "QuteElementType.NAMESPACE_EXPR";
+    private static final String QUTE_JETBRAINS_QUALIFIER = "QuteElementType.QUALIFIER";
+    private static final String QUTE_JETBRAINS_CALL_EXPR = "QuteElementType.CALL_EXPR";
 
     @Override
     public @NotNull Collection<DebugVariablePositionProvider> getDebugVariablePositionProvider() {
@@ -117,8 +117,8 @@ public class QuteDebugAdapterVariableSupport extends DebugAdapterVariableSupport
         return node != null ? node.getElementType() : null;
     }
 
-    private static boolean isTokenType(@Nullable IElementType tokenType, @NotNull String tokenName) {
-        return tokenType != null && tokenName.equals(tokenType.getDebugName());
+    public static boolean isTokenType(@Nullable IElementType tokenType, @NotNull String tokenName) {
+        return tokenType != null && tokenName.equals(tokenType.toString());
     }
 
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/run/QuteVariableRangeRegistrar.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/run/QuteVariableRangeRegistrar.java
@@ -19,6 +19,9 @@ import com.redhat.devtools.lsp4ij.dap.client.variables.providers.DebugVariableCo
 import com.redhat.devtools.lsp4ij.dap.client.variables.providers.DefaultVariableRangeRegistrar;
 import org.jetbrains.annotations.NotNull;
 
+import static com.redhat.devtools.intellij.qute.run.QuteDebugAdapterVariableSupport.QUTE_JETBRAINS_IDENTIFIER;
+import static com.redhat.devtools.intellij.qute.run.QuteDebugAdapterVariableSupport.isTokenType;
+
 /**
  * Qute variable range registar.
  */
@@ -32,7 +35,7 @@ public class QuteVariableRangeRegistrar extends DefaultVariableRangeRegistrar {
             context.addVariableRange(variableName, textRange);
         } else if (QuteLanguage.isQuteLanguage(tokenType.getLanguage())) {
             if (!(tokenType instanceof QuteTokenType)) {
-                if (QuteDebugAdapterVariableSupport.QUTE_JETBRAINS_IDENTIFIER.equals(tokenType.getDebugName())) {
+                if (isTokenType(tokenType, QUTE_JETBRAINS_IDENTIFIER)) {
                     TextRange textRange = new TextRange(start, end);
                     String variableName = document.getText(textRange);
                     context.addVariableRange(variableName, textRange);


### PR DESCRIPTION
fix: Avoid using IElementType#getDebugName() internal method