### PR TITLE
fix: don't report false positive error when @TemplateContents is declared

### DIFF
--- a/projects/qute/projects/maven/qute-record/pom.xml
+++ b/projects/qute/projects/maven/qute-record/pom.xml
@@ -12,7 +12,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.12.1</quarkus.platform.version>
+        <quarkus.platform.version>3.29.0</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.2.5</surefire-plugin.version>
     </properties>

--- a/projects/qute/projects/maven/qute-record/src/main/java/org/acme/sample/HelloResource.java
+++ b/projects/qute/projects/maven/qute-record/src/main/java/org/acme/sample/HelloResource.java
@@ -7,7 +7,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-
+import io.quarkus.qute.TemplateContents;
 import io.quarkus.qute.TemplateInstance;
 
 @Path("hello")
@@ -21,6 +21,9 @@ public class HelloResource {
 
     @CheckedTemplate(basePath="Foo", defaultName=CheckedTemplate.HYPHENATED_ELEMENT_NAME)
     record HelloWorld(String name) implements TemplateInstance {}
+
+    @TemplateContents("Hello {name}!")
+    record HelloWithTemplateContents(String name) implements TemplateInstance {}
 
     @GET
     @Produces(MediaType.TEXT_PLAIN)

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/QuteJavaConstants.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/QuteJavaConstants.java
@@ -105,6 +105,10 @@ public class QuteJavaConstants {
 
     public static final String REGISTER_FOR_REFLECTION_ANNOTATION_TARGETS = "targets";
 
+    // @TemplateContents
+
+    public static final String TEMPLATE_CONTENTS_ANNOTATION = "io.quarkus.qute.TemplateContents";
+
     // @Message
     public static final String MESSAGE_BUNDLE_ANNOTATION = "io.quarkus.qute.i18n.MessageBundle";
     public static final String MESSAGE_BUNDLE_ANNOTATION_LOCALE = "locale";

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/java/AbstractQuteTemplateLinkCollector.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/java/AbstractQuteTemplateLinkCollector.java
@@ -184,7 +184,7 @@ public abstract class AbstractQuteTemplateLinkCollector extends JavaRecursiveEle
      * Records</a>
      */
     private void visitRecordType(PsiClass node) {
-        if (isImplementTemplateInstance(node)) {
+        if (isImplementTemplateInstance(node) && !isTemplateContents(node)) {
 
             // public class HelloResource {
             // record Hello(String name) implements TemplateInstance {}
@@ -196,6 +196,10 @@ public abstract class AbstractQuteTemplateLinkCollector extends JavaRecursiveEle
             collectTemplateLinkForMethodOrRecord(basePath, node, recordName, node, ignoreFragments,
                     templateNameStrategy);
         }
+    }
+
+    private static boolean isTemplateContents(PsiClass node) {
+        return AnnotationUtils.hasAnnotation(node, TEMPLATE_CONTENTS_ANNOTATION);
     }
 
     /**


### PR DESCRIPTION
fix: don't report false positive error when @TemplateContents is declared

![TemplateContentsDemo](https://github.com/user-attachments/assets/b61d071e-7fb5-43b8-9f08-74991cdc7c50)
