### PR TITLE
feat: Qute debugging in Java file

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteFileViewProvider.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteFileViewProvider.java
@@ -10,17 +10,23 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.qute.lang;
 
+import com.intellij.injected.editor.VirtualFileWindow;
 import com.intellij.lang.Language;
 import com.intellij.lang.LanguageParserDefinitions;
 import com.intellij.lang.ParserDefinition;
+import com.intellij.lang.java.JavaLanguage;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.fileTypes.FileTypeManager;
 import com.intellij.openapi.fileTypes.LanguageFileType;
+import com.intellij.openapi.fileTypes.PlainTextLanguage;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.MultiplePsiFilesPerDocumentFileViewProvider;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.impl.source.PsiFileImpl;
+import com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtilBase;
 import com.intellij.psi.templateLanguages.TemplateLanguageFileViewProvider;
 import com.intellij.psi.tree.IElementType;
 import com.redhat.devtools.intellij.qute.lang.psi.QuteElementTypes;
@@ -31,42 +37,92 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
- * Qute file view provider.
+ * File view provider for Qute templates.
+ * <p>
+ * This provider supports template languages embedded in Qute files
+ * (e.g. HTML, YAML) and manages the association between the base Qute
+ * language and the underlying template data language.
  */
-public class QuteFileViewProvider extends MultiplePsiFilesPerDocumentFileViewProvider implements TemplateLanguageFileViewProvider {
+public class QuteFileViewProvider
+        extends MultiplePsiFilesPerDocumentFileViewProvider
+        implements TemplateLanguageFileViewProvider {
+
+    /**
+     * Key used to store and retrieve the template language associated
+     * with an injected Qute {@link com.intellij.psi.PsiLiteralExpression}.
+     */
+    public static final Key<Language> TEMPLATE_LANGUAGE_KEY =
+            Key.create("Qute.TemplateLanguage");
+
     private final @NotNull Language language;
     private final @NotNull Language templateLanguage;
 
-    public QuteFileViewProvider(@NotNull VirtualFile file, @NotNull Language language, @NotNull PsiManager manager, boolean eventSystemEnabled) {
-        this(file, language, getTemplateLanguage(file), manager, eventSystemEnabled);
+    public QuteFileViewProvider(@NotNull VirtualFile file,
+                                @NotNull Language language,
+                                @NotNull PsiManager manager,
+                                boolean eventSystemEnabled) {
+        this(file, language, getTemplateLanguage(file, manager.getProject()), manager, eventSystemEnabled);
     }
 
-    private QuteFileViewProvider(@NotNull VirtualFile file, @NotNull Language language, @NotNull Language templateLanguage, @NotNull PsiManager manager, boolean eventSystemEnabled) {
+    private QuteFileViewProvider(@NotNull VirtualFile file,
+                                 @NotNull Language language,
+                                 @NotNull Language templateLanguage,
+                                 @NotNull PsiManager manager,
+                                 boolean eventSystemEnabled) {
         super(manager, file, eventSystemEnabled);
         this.language = language;
         this.templateLanguage = templateLanguage;
     }
 
     /**
-     * Returns the template language of the given file (ex : "HTML", "YAML", language etc) and the "Qute_" language otherwise.
+     * Determines the template language associated with the given file.
+     * <p>
+     * The template language is inferred from the file extension
+     * (e.g. HTML, YAML). If no specific language can be determined,
+     * {@link QuteLanguage} is used as a fallback.
+     * <p>
+     * When Qute content is injected into a Java file, the template
+     * language is retrieved from the injection host via
+     * {@link #TEMPLATE_LANGUAGE_KEY}.
      *
-     * @param file the virtual file.
-     *
-     * @return the template language of the given file (ex : "HTML", "YAML", language etc) and the "Qute_" language otherwise.
+     * @param file    the virtual file
+     * @param project the current project
+     * @return the resolved template language, or a fallback language
      */
-    public static @NotNull Language getTemplateLanguage(@NotNull VirtualFile file) {
+    public static @NotNull Language getTemplateLanguage(@NotNull VirtualFile file,
+                                                        @NotNull Project project) {
         @Nullable String fileExtension = file.getExtension();
-        FileType fileType = fileExtension != null ? FileTypeManager.getInstance().getFileTypeByExtension(fileExtension) : null;
-        return fileType instanceof LanguageFileType ? ((LanguageFileType) fileType).getLanguage() : QuteLanguage.INSTANCE;
+        FileType fileType = fileExtension != null
+                ? FileTypeManager.getInstance().getFileTypeByExtension(fileExtension)
+                : null;
+
+        Language language = fileType instanceof LanguageFileType
+                ? ((LanguageFileType) fileType).getLanguage()
+                : QuteLanguage.INSTANCE;
+
+        if (language.is(JavaLanguage.INSTANCE) && file instanceof VirtualFileWindow) {
+            // Injected Qute content inside a Java file:
+            // retrieve the template language from the injection host.
+            var host = InjectedLanguageUtilBase.findInjectionHost(file);
+            @Nullable Language templateLanguage =
+                    host != null ? host.getUserData(TEMPLATE_LANGUAGE_KEY) : null;
+            return templateLanguage != null
+                    ? templateLanguage
+                    : PlainTextLanguage.INSTANCE;
+        }
+        return language;
     }
 
+    @Override
     protected PsiFile createFile(@NotNull Language lang) {
         if (lang == getTemplateDataLanguage()) {
-            final ParserDefinition parserDefinition = LanguageParserDefinitions.INSTANCE.forLanguage(lang);
+            ParserDefinition parserDefinition =
+                    LanguageParserDefinitions.INSTANCE.forLanguage(lang);
             if (parserDefinition != null) {
                 PsiFile file = parserDefinition.createFile(this);
                 if (file instanceof PsiFileImpl) {
-                    ((PsiFileImpl) file).setContentElementType(QuteElementTypes.QUTE_FILE_DATA);
+                    ((PsiFileImpl) file)
+                            .setContentElementType(QuteElementTypes.QUTE_FILE_DATA);
                 }
                 return file;
             }
@@ -74,11 +130,18 @@ public class QuteFileViewProvider extends MultiplePsiFilesPerDocumentFileViewPro
         return super.createFile(lang);
     }
 
+    /**
+     * @return the base language of this view provider (Qute).
+     */
     @Override
     public @NotNull Language getBaseLanguage() {
         return language;
     }
 
+    /**
+     * @return all languages handled by this view provider
+     * (base Qute language and template data language).
+     */
     @Override
     public @NotNull Set<Language> getLanguages() {
         Set<Language> languages = new LinkedHashSet<>();
@@ -87,6 +150,9 @@ public class QuteFileViewProvider extends MultiplePsiFilesPerDocumentFileViewPro
         return languages;
     }
 
+    /**
+     * @return the language used for the template data (e.g. HTML, YAML).
+     */
     @Override
     public @NotNull Language getTemplateDataLanguage() {
         return templateLanguage;
@@ -94,11 +160,20 @@ public class QuteFileViewProvider extends MultiplePsiFilesPerDocumentFileViewPro
 
     @Override
     public IElementType getContentElementType(@NotNull Language language) {
-        return language == getTemplateDataLanguage() ? QuteElementTypes.QUTE_FILE_DATA : null;
+        return language == getTemplateDataLanguage()
+                ? QuteElementTypes.QUTE_FILE_DATA
+                : null;
     }
 
     @Override
-    protected @NotNull MultiplePsiFilesPerDocumentFileViewProvider cloneInner(@NotNull VirtualFile fileCopy) {
-        return new QuteFileViewProvider(fileCopy, getBaseLanguage(), getTemplateDataLanguage(), getManager(), false);
+    protected @NotNull MultiplePsiFilesPerDocumentFileViewProvider cloneInner(
+            @NotNull VirtualFile fileCopy) {
+        return new QuteFileViewProvider(
+                fileCopy,
+                getBaseLanguage(),
+                getTemplateDataLanguage(),
+                getManager(),
+                false
+        );
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteLanguageSubstitutor.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteLanguageSubstitutor.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.qute.lang;
 
+import com.intellij.ide.highlighter.JavaFileType;
+import com.intellij.injected.editor.VirtualFileWindow;
 import com.intellij.lang.Language;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleManager;

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/highlighter/QuteEditorHighlighter.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/highlighter/QuteEditorHighlighter.java
@@ -30,7 +30,7 @@ public class QuteEditorHighlighter extends LayeredLexerEditorHighlighter {
     public QuteEditorHighlighter(@Nullable Project project, @Nullable VirtualFile virtualFile, @NotNull EditorColorsScheme scheme) {
         super(new QuteSyntaxHighlighter(), scheme);
         if (virtualFile != null) {
-            Language templateLanguage = QuteFileViewProvider.getTemplateLanguage(virtualFile);
+            Language templateLanguage = QuteFileViewProvider.getTemplateLanguage(virtualFile, project);
             this.registerLayer(QuteElementTypes.QUTE_TEXT,
                     new LayerDescriptor(
                             SyntaxHighlighterFactory.getSyntaxHighlighter(templateLanguage, project, virtualFile),""));

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/injector/QuteJavaInjectionDescriptor.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/injector/QuteJavaInjectionDescriptor.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.qute.lang.injector;
+
+import com.intellij.lang.Language;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Function;
+
+/**
+ * Describes an annotation that supports Qute template injection in Java code.
+ * Provides a way to retrieve the template data language based on the PsiElement.
+ */
+public class QuteJavaInjectionDescriptor {
+
+    private final @NotNull String annotationName;
+    private final @Nullable Function<PsiElement, Language> templateLanguageProvider;
+
+    /**
+     * Creates a descriptor for a Qute-injectable annotation.
+     *
+     * @param annotationName the fully qualified name of the annotation
+     */
+    public QuteJavaInjectionDescriptor(@NotNull String annotationName) {
+        this(annotationName, null);
+    }
+
+    /**
+     * Creates a descriptor for a Qute-injectable annotation.
+     *
+     * @param annotationName the fully qualified name of the annotation
+     * @param templateLanguageProvider function to determine the template language from a PsiElement (e.g., literal)
+     */
+    public QuteJavaInjectionDescriptor(@NotNull String annotationName,
+                                       @Nullable Function<PsiElement, Language> templateLanguageProvider) {
+        this.annotationName = annotationName;
+        this.templateLanguageProvider = templateLanguageProvider;
+    }
+
+    /**
+     * @return the fully qualified name of the annotation
+     */
+    public @NotNull String getAnnotationName() {
+        return annotationName;
+    }
+
+    /**
+     * Determines the template language for the given element (literal) using the provider.
+     *
+     * @param element the PsiElement to inspect
+     * @return the Language to use for Qute injection, or null if none
+     */
+    public @Nullable Language getTemplateDataLanguage(@NotNull PsiElement element) {
+        return templateLanguageProvider != null ? templateLanguageProvider.apply(element) : null;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/injector/QuteJavaInjectionRegistry.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/injector/QuteJavaInjectionRegistry.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.qute.lang.injector;
+
+import com.intellij.lang.Language;
+import com.intellij.lang.html.HTMLLanguage;
+import com.intellij.lang.xml.XMLLanguage;
+import com.intellij.openapi.fileTypes.PlainTextLanguage;
+import com.intellij.psi.PsiAnnotation;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.redhat.devtools.intellij.qute.psi.internal.QuteJavaConstants;
+import org.eclipse.lsp4mp.commons.utils.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Registry of Java annotations that embed Qute template content.
+ * <p>
+ * Provides access to {@link QuteJavaInjectionDescriptor} for each annotation,
+ * including logic for determining the template data language (HTML, text, XML, etc.).
+ */
+public class QuteJavaInjectionRegistry {
+
+    private static final QuteJavaInjectionRegistry INSTANCE = new QuteJavaInjectionRegistry();
+    private final Map<String, QuteJavaInjectionDescriptor> descriptorsByAnnotation;
+
+    private QuteJavaInjectionRegistry() {
+        this.descriptorsByAnnotation = new HashMap<>();
+
+        // --- Qute core ---
+        registerDescriptor(new QuteJavaInjectionDescriptor(
+                QuteJavaConstants.TEMPLATE_CONTENTS_ANNOTATION,
+                element -> {
+                    PsiAnnotation annotation = PsiTreeUtil.getParentOfType(
+                            element, PsiAnnotation.class
+                    );
+                    if (annotation == null) {
+                        return null;
+                    }
+                    //  @TemplateContents(value = "<p>He <a></a>  <a></a> Hello2 {name}!}</p>",
+                    //                    suffix = "html")
+                    //    record HelloWithHtml(String name) implements TemplateInstance {}
+                    String suffix = com.intellij.codeInsight.AnnotationUtil
+                            .getDeclaredStringAttributeValue(annotation, "suffix");
+                    return mapSuffixToLanguage(suffix);
+                }
+        ));
+
+        registerDescriptor(new QuteJavaInjectionDescriptor(QuteJavaConstants.MESSAGE_ANNOTATION));
+
+        // --- langchain4j ---
+        registerDescriptor(new QuteJavaInjectionDescriptor("dev.langchain4j.service.UserMessage"));
+        registerDescriptor(new QuteJavaInjectionDescriptor("dev.langchain4j.service.SystemMessage"));
+    }
+
+    public static QuteJavaInjectionRegistry getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Maps a suffix string to the corresponding IntelliJ Language.
+     *
+     * @param suffix the suffix, e.g. "html", "xml", "json", "yaml"
+     * @return the corresponding Language instance, or PlainText if unknown/null
+     */
+    private static @NotNull Language mapSuffixToLanguage(@Nullable String suffix) {
+        if (StringUtils.isEmpty(suffix)) {
+            return PlainTextLanguage.INSTANCE;
+        }
+        switch (suffix.toLowerCase()) {
+            case "html":
+                return HTMLLanguage.INSTANCE;
+            case "xml":
+                return XMLLanguage.INSTANCE;
+            case "json": {
+                Language lang = Language.findLanguageByID("JSON"); // optional plugin
+                return lang != null ? lang : PlainTextLanguage.INSTANCE;
+            }
+            case "yaml":
+            case "yml": {
+                Language lang = Language.findLanguageByID("YAML"); // optional plugin
+                return lang != null ? lang : PlainTextLanguage.INSTANCE;
+            }
+            default:
+                return PlainTextLanguage.INSTANCE;
+        }
+    }
+
+    private void registerDescriptor(@NotNull QuteJavaInjectionDescriptor descriptor) {
+        descriptorsByAnnotation.put(descriptor.getAnnotationName(), descriptor);
+    }
+
+    /**
+     * Returns the descriptor for the given annotation, or null if not registered.
+     */
+    public @Nullable QuteJavaInjectionDescriptor getDescriptor(@Nullable PsiAnnotation annotation) {
+        if (annotation == null) {
+            return null;
+        }
+        return descriptorsByAnnotation.get(annotation.getQualifiedName());
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/injector/QuteLanguageInjector.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/injector/QuteLanguageInjector.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.qute.lang.injector;
+
+import com.intellij.lang.injection.MultiHostInjector;
+import com.intellij.lang.injection.MultiHostRegistrar;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.redhat.devtools.intellij.qute.lang.QuteFileViewProvider;
+import com.redhat.devtools.intellij.qute.lang.QuteLanguage;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Language injector that applies Qute syntax highlighting to Java string
+ * literals.
+ * <p>
+ * This injector enables Qute language support inside
+ * {@link PsiLiteralExpression} instances, typically used in annotations.
+ * <p>
+ * Supported cases include:
+ * <ul>
+ *   <li>Java text blocks ({@code """..."""})</li>
+ *   <li>Standard string literals ({@code "..."})</li>
+ *   <li>Line breaks ({@code \n} and {@code \r\n})</li>
+ *   <li>Empty or malformed literals (safely ignored)</li>
+ * </ul>
+ */
+public class QuteLanguageInjector implements MultiHostInjector {
+
+    /**
+     * Computes the inner text range of a Java string literal that should
+     * receive Qute language injection.
+     * <p>
+     * The returned range excludes surrounding quotes and, in the case of
+     * text blocks, the optional newline immediately following the opening
+     * {@code """}.
+     *
+     * @param context     the PSI context element
+     * @param host        the language injection host
+     * @param descriptor  Qute Java injection descriptor
+     * @return the inner text range to inject into, or {@code null} if the
+     *         literal is not suitable for injection
+     */
+    private static @Nullable TextRange getInnerRange(@NotNull PsiElement context,
+                                                     @NotNull PsiLanguageInjectionHost host,
+                                                     @NotNull QuteJavaInjectionDescriptor descriptor) {
+
+        // If the literal is part of an annotation attribute, only inject
+        // into the default "value" attribute
+        PsiElement parent = context.getParent();
+        if (parent instanceof PsiNameValuePair pair) {
+            String name = pair.getName();
+            if (name != null && !"value".equals(name)) {
+                return null;
+            }
+        }
+
+        String text = host.getText();
+        if (text == null || text.length() < 2) {
+            return null;
+        }
+
+        int innerStart;
+        int innerEnd;
+
+        // Java text block: """..."""
+        if (text.startsWith("\"\"\"") && text.endsWith("\"\"\"") && text.length() >= 6) {
+            innerStart = 3;
+            innerEnd = text.length() - 3;
+
+            // Skip the newline immediately following the opening """
+            if (innerStart < text.length()) {
+                char c = text.charAt(innerStart);
+                if (c == '\n') {
+                    innerStart++;
+                } else if (c == '\r') {
+                    innerStart++;
+                    if (innerStart < text.length() && text.charAt(innerStart) == '\n') {
+                        innerStart++;
+                    }
+                }
+            }
+        }
+        // Standard string literal: "..."
+        else if (text.startsWith("\"") && text.endsWith("\"")) {
+            innerStart = 1;
+            innerEnd = text.length() - 1;
+        } else {
+            // Not a supported string literal
+            return null;
+        }
+
+        // Ensure the computed range is valid
+        if (innerStart >= innerEnd) {
+            return null;
+        }
+
+        return new TextRange(innerStart, innerEnd);
+    }
+
+    @Override
+    public void getLanguagesToInject(@NotNull MultiHostRegistrar registrar,
+                                     @NotNull PsiElement context) {
+
+        // Only process Java string literals
+        if (!(context instanceof PsiLiteralExpression literal)) {
+            return;
+        }
+
+        // Ensure the literal supports language injection
+        if (!(literal instanceof PsiLanguageInjectionHost host)) {
+            return;
+        }
+
+        // Locate the enclosing annotation (if any)
+        PsiAnnotation annotation =
+                PsiTreeUtil.getParentOfType(literal, PsiAnnotation.class);
+
+        QuteJavaInjectionDescriptor descriptor =
+                QuteJavaInjectionRegistry.getInstance().getDescriptor(annotation);
+
+        if (descriptor == null) {
+            return;
+        }
+
+        TextRange innerRange = getInnerRange(context, host, descriptor);
+        if (innerRange != null) {
+            // Store the template language on the host for later retrieval
+            var templateLanguage = descriptor.getTemplateDataLanguage(context);
+            host.putUserData(QuteFileViewProvider.TEMPLATE_LANGUAGE_KEY, templateLanguage);
+
+            // Inject Qute language into the computed text range
+            registrar.startInjecting(QuteLanguage.INSTANCE)
+                    .addPlace(null, null, host, innerRange)
+                    .doneInjecting();
+        }
+    }
+
+    @NotNull
+    @Override
+    public List<? extends Class<? extends PsiElement>> elementsToInjectIn() {
+        // Restrict injection targets to Java string literals
+        return Collections.singletonList(PsiLiteralExpression.class);
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/run/QuteBreakpointType.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/run/QuteBreakpointType.java
@@ -10,11 +10,26 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.qute.run;
 
+import com.intellij.lang.Language;
+import com.intellij.lang.java.JavaLanguage;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTreeUtil;
+import com.intellij.util.DocumentUtil;
+import com.intellij.xdebugger.XDebuggerUtil;
 import com.intellij.xdebugger.breakpoints.XBreakpointProperties;
+import com.redhat.devtools.intellij.qute.lang.QuteLanguage;
+import com.redhat.devtools.intellij.qute.lang.injector.QuteJavaInjectionRegistry;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
 import com.redhat.devtools.lsp4ij.dap.breakpoints.DAPBreakpointTypeBase;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.function.BiFunction;
 
 /**
  * Qute breakpoint type.
@@ -30,6 +45,97 @@ public class QuteBreakpointType extends DAPBreakpointTypeBase<XBreakpointPropert
     @Override
     public @Nullable XBreakpointProperties<?> createBreakpointProperties(@NotNull VirtualFile virtualFile, int line) {
         return null;
+    }
+
+    @Override
+    public boolean canPutAt(@NotNull VirtualFile file, int line, @NotNull Project project) {
+        Language language = LSPIJUtils.getFileLanguage(file, project);
+        if (language == null) {
+            return false;
+        }
+        if (QuteLanguage.isQuteLanguage(language)) {
+            return true;
+        }
+        if (language.equals(JavaLanguage.INSTANCE)) {
+            return canPutAtElement(file, line, project, (element, document) -> {
+                if (element instanceof PsiAnnotation annotation) {
+                    return QuteJavaInjectionRegistry.getInstance().getDescriptor(annotation) != null;
+                }
+                return false;
+            });
+        }
+        return false;
+    }
+
+    private static boolean canPutAtElement(final @NotNull VirtualFile file,
+                                           final int line,
+                                           @NotNull Project project,
+                                           @NotNull BiFunction<? super PsiElement, ? super Document, Boolean> processor) {
+        PsiFile psiFile = PsiManager.getInstance(project).findFile(file);
+        if (psiFile == null) {
+            return false;
+        }
+        Language language = psiFile.getLanguage();
+        if (!JavaLanguage.INSTANCE.equals(language)) {
+            return false;
+        }
+
+        Document document = FileDocumentManager.getInstance().getDocument(file);
+        if (document != null) {
+            Ref<Boolean> res = Ref.create(false);
+            XDebuggerUtil.getInstance().iterateLine(project, document, line, element -> {
+                // avoid comments
+                if ((element instanceof PsiWhiteSpace)
+                        || (PsiTreeUtil.getNonStrictParentOfType(element, PsiComment.class, PsiImportStatementBase.class, PsiPackageStatement.class) != null)) {
+                    return true;
+                }
+                if (element instanceof PsiJavaToken javaToken && javaToken.getTokenType() == JavaTokenType.TEXT_BLOCK_LITERAL) {
+                    PsiElement parent = element;
+                    while (element != null) {
+                        element = element.getParent();
+                        if (element instanceof PsiAnnotation) {
+                            if (processor.apply(element, document)) {
+                                res.set(true);
+                                return false;
+                            }
+                        }
+                    }
+                    return false;
+                }
+                if (element == JavaTokenType.AT) {
+                    PsiElement prev = element.getPrevSibling();
+                    if (prev instanceof PsiAnnotation) {
+                        return true;
+                    }
+                }
+
+
+                PsiElement parent = element;
+                while (element != null) {
+                    // skip modifiers
+
+                    if (element instanceof PsiModifierList) {
+                        element = element.getParent();
+                        continue;
+                    }
+
+                    final int offset = element.getTextOffset();
+                    if (!DocumentUtil.isValidOffset(offset, document) || document.getLineNumber(offset) != line) {
+                        break;
+                    }
+                    parent = element;
+                    element = element.getParent();
+                }
+
+                if (processor.apply(parent, document)) {
+                    res.set(true);
+                    return false;
+                }
+                return true;
+            });
+            return res.get();
+        }
+        return false;
     }
 
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/run/QuteDebugAdapterDescriptor.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/run/QuteDebugAdapterDescriptor.java
@@ -22,15 +22,18 @@ import com.intellij.xdebugger.breakpoints.XBreakpointProperties;
 import com.intellij.xdebugger.breakpoints.XLineBreakpoint;
 import com.intellij.xdebugger.evaluation.XDebuggerEditorsProvider;
 import com.redhat.devtools.intellij.qute.lang.QuteFileType;
+import com.redhat.devtools.intellij.qute.run.client.QuteDAPClient;
 import com.redhat.devtools.lsp4ij.dap.DAPDebugProcess;
 import com.redhat.devtools.lsp4ij.dap.DAPDebuggerEditorsProvider;
 import com.redhat.devtools.lsp4ij.dap.DebugMode;
 import com.redhat.devtools.lsp4ij.dap.breakpoints.DAPBreakpointHandler;
 import com.redhat.devtools.lsp4ij.dap.breakpoints.DAPBreakpointHandlerBase;
 import com.redhat.devtools.lsp4ij.dap.breakpoints.DAPBreakpointProperties;
+import com.redhat.devtools.lsp4ij.dap.client.DAPClient;
 import com.redhat.devtools.lsp4ij.dap.client.LaunchUtils;
 import com.redhat.devtools.lsp4ij.dap.definitions.DebugAdapterServerDefinition;
 import com.redhat.devtools.lsp4ij.dap.descriptors.DebugAdapterDescriptor;
+import com.redhat.devtools.lsp4ij.settings.ServerTrace;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -85,5 +88,10 @@ public class QuteDebugAdapterDescriptor extends DebugAdapterDescriptor {
     @Override
     public @NotNull XDebuggerEditorsProvider createDebuggerEditorsProvider(@Nullable FileType fileType, @NotNull DAPDebugProcess debugProcess) {
         return new QuteDebuggerEditorsProvider(fileType, debugProcess);
+    }
+
+    @Override
+    public @NotNull DAPClient createClient(@NotNull DAPDebugProcess debugProcess, @NotNull Map<String, Object> dapParameters, boolean isDebug, @NotNull DebugMode debugMode, @NotNull ServerTrace serverTrace, @Nullable DAPClient parentClient) {
+        return new QuteDAPClient(debugProcess, dapParameters, isDebug, debugMode, serverTrace, parentClient);
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/run/QuteDebugAdapterDescriptorFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/run/QuteDebugAdapterDescriptorFactory.java
@@ -13,6 +13,7 @@ package com.redhat.devtools.intellij.qute.run;
 import com.intellij.execution.configurations.RunConfigurationOptions;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.lang.Language;
+import com.intellij.lang.java.JavaLanguage;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.xdebugger.breakpoints.XBreakpointType;
@@ -41,6 +42,6 @@ public class QuteDebugAdapterDescriptorFactory extends DebugAdapterDescriptorFac
     @Override
     public boolean isDebuggableFile(@NotNull VirtualFile file, @NotNull Project project) {
         Language language = LSPIJUtils.getFileLanguage(file, project);
-        return QuteLanguage.isQuteLanguage(language);
+        return language != null && (QuteLanguage.isQuteLanguage(language) || language.equals(JavaLanguage.INSTANCE));
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/run/client/JavaSourceLocationArguments.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/run/client/JavaSourceLocationArguments.java
@@ -1,0 +1,113 @@
+package com.redhat.devtools.intellij.qute.run.client;
+
+/**
+ * Arguments describing a Java element referenced from a Qute template.
+ * <p>
+ * Sent by the Debug Adapter via {@link JavaSourceResolver#resolveJavaSource}
+ * to the client in order to locate the corresponding Java source file and position.
+ * </p>
+ *
+ * <h2>Example of a qute-java URI</h2>
+ * <pre>
+ * qute-java://com.acme.Bean#process@io.quarkus.qute.TemplateContents
+ * </pre>
+ *
+ * <p>Interpretation:</p>
+ * <ul>
+ *   <li>javaElementUri = "qute-java://com.acme.Bean#process@io.quarkus.qute.TemplateContents"</li>
+ *   <li>typeName = "com.acme.Bean"</li>
+ *   <li>method = "process" (optional; if null, the annotation is applied on the class)</li>
+ *   <li>annotation = "io.quarkus.qute.TemplateContents"</li>
+ * </ul>
+ */
+public class JavaSourceLocationArguments {
+
+    /** The qute-java URI used to locate the Java element from a template. */
+    private String javaElementUri;
+
+    /** Fully qualified Java class, interface name (e.g., "com.acme.Bean"). */
+    private String typeName;
+
+    /**
+     * Java method name.
+     * <p>
+     * Optional: if {@code null}, the annotation is applied to the class itself.
+     * </p>
+     */
+    private String method;
+
+    /** Fully qualified Java annotation name (typically "io.quarkus.qute.TemplateContents"). */
+    private String annotation;
+
+    /**
+     * Returns the qute-java URI used to locate the Java element.
+     *
+     * @return the URI string
+     */
+    public String getJavaElementUri() {
+        return javaElementUri;
+    }
+
+    /**
+     * Sets the qute-java URI used to locate the Java element.
+     *
+     * @param javaElementUri the URI string to set
+     */
+    public void setJavaElementUri(String javaElementUri) {
+        this.javaElementUri = javaElementUri;
+    }
+
+    /**
+     * Returns the fully qualified Java class, interface name.
+     *
+     * @return the class name
+     */
+    public String getTypeName() {
+        return typeName;
+    }
+
+    /**
+     * Sets the fully qualified Java class, interface name.
+     *
+     * @param typeName the class, interface name to set
+     */
+    public void setTypeName(String typeName) {
+        this.typeName = typeName;
+    }
+
+    /**
+     * Returns the Java method name.
+     *
+     * @return the method name, or {@code null} if the annotation applies to the class
+     */
+    public String getMethod() {
+        return method;
+    }
+
+    /**
+     * Sets the Java method name.
+     *
+     * @param method the method name to set, or {@code null} if the annotation applies to the class
+     */
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    /**
+     * Returns the fully qualified Java annotation name.
+     *
+     * @return the annotation name (e.g., "io.quarkus.qute.TemplateContents")
+     */
+    public String getAnnotation() {
+        return annotation;
+    }
+
+    /**
+     * Sets the fully qualified Java annotation name.
+     *
+     * @param annotation the annotation name to set
+     */
+    public void setAnnotation(String annotation) {
+        this.annotation = annotation;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/run/client/JavaSourceLocationResponse.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/run/client/JavaSourceLocationResponse.java
@@ -1,0 +1,70 @@
+package com.redhat.devtools.intellij.qute.run.client;
+
+/**
+ * Response containing the location of a Java method, class, or template content
+ * referenced from a Qute template.
+ * <p>
+ * Typically returned by {@link JavaSourceResolver#resolveJavaSource}.
+ * </p>
+ *
+ * <h2>Example</h2>
+ * <pre>
+ * qute-java://org.acme.quarkus.sample.HelloResource$Hello@io.quarkus.qute.TemplateContents
+ * → javaFileUri = "file:///project/src/main/java/org/acme/quarkus/sample/HelloResource.java"
+ * → startLine = 16
+ * </pre>
+ *
+ * <p>
+ * The {@code startLine} represents the line where the template content or the Java
+ * element declaration starts. Lines are 1-based in this API (first line = 1).
+ * </p>
+ */
+public class JavaSourceLocationResponse {
+
+    /** URI of the Java source file containing the resolved element. */
+    private String javaFileUri;
+
+    /**
+     * Start line of the Java element or template content in the file.
+     * <p>
+     * 1-based index of the line where the element or template content starts.
+     * </p>
+     */
+    private int startLine;
+
+    /**
+     * Returns the URI of the Java source file containing the resolved element.
+     *
+     * @return the file URI
+     */
+    public String getJavaFileUri() {
+        return javaFileUri;
+    }
+
+    /**
+     * Sets the URI of the Java source file containing the resolved element.
+     *
+     * @param javaFileUri the file URI to set
+     */
+    public void setJavaFileUri(String javaFileUri) {
+        this.javaFileUri = javaFileUri;
+    }
+
+    /**
+     * Returns the start line of the Java element or template content in the source file.
+     *
+     * @return 1-based start line of the element or template content
+     */
+    public int getStartLine() {
+        return startLine;
+    }
+
+    /**
+     * Sets the start line of the Java element or template content in the source file.
+     *
+     * @param startLine 1-based start line of the element or template content
+     */
+    public void setStartLine(int startLine) {
+        this.startLine = startLine;
+    }
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/run/client/JavaSourceResolver.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/run/client/JavaSourceResolver.java
@@ -1,0 +1,85 @@
+package com.redhat.devtools.intellij.qute.run.client;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+
+/**
+ * Resolver for Java source locations referenced from Qute templates.
+ * <p>
+ * Implementations of this interface provide a way to resolve a Qute template reference
+ * (via a {@code qute-java://} URI) to the corresponding Java source file and template position.
+ * </p>
+ *
+ * <p>
+ * This resolver is used by the Debug Adapter Protocol (DAP) **only to support breakpoints**
+ * on Java methods or classes related to Qute templates.
+ * </p>
+ *
+ * <h2>Example with a Qute template in a JAX-RS resource</h2>
+ * <pre>
+ * package org.acme.quarkus.sample;
+ * 
+ * import jakarta.ws.rs.GET;
+ * import jakarta.ws.rs.Path;
+ * import jakarta.ws.rs.QueryParam;
+ * import jakarta.ws.rs.Produces;
+ * import jakarta.ws.rs.core.MediaType;
+ * 
+ * import io.quarkus.qute.TemplateContents;
+ * import io.quarkus.qute.TemplateInstance;
+ * 
+ * &#64;Path("hello")
+ * public class HelloResource { 
+ *     
+ *     &#64;TemplateContents(
+ *         """
+ *         &lt;p&gt;Hello {name ?: "Qute"}&lt;/p&gt;!
+ *         """
+ *     )
+ *     record Hello(String name) implements TemplateInstance {}
+ * 
+ *     &#64;GET
+ *     &#64;Produces(MediaType.TEXT_PLAIN)
+ *     public TemplateInstance get(@QueryParam("name") String name) {
+ *         return new Hello(name);
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>Corresponding {@code qute-java://} URI for the record:</p>
+ * <pre>
+ * qute-java://org.acme.quarkus.sample.HelloResource$Hello@io.quarkus.qute.TemplateContents
+ * </pre>
+ *
+ * <p>Parsed into {@link JavaSourceLocationArguments}:</p>
+ * <ul>
+ *   <li>unresolvedUri = "qute-java://org.acme.quarkus.sample.HelloResource$Hello@io.quarkus.qute.TemplateContents"</li>
+ *   <li>typeName = "org.acme.quarkus.sample.HelloResource$Hello"</li>
+ *   <li>method = null (the annotation is on the record class)</li>
+ *   <li>annotation = "io.quarkus.qute.TemplateContents"</li>
+ * </ul>
+ *
+ * <p>Example resulting {@link JavaSourceLocationResponse}:</p>
+ * <ul>
+ *   <li>javaFileUri = "file:///path/to/project/src/main/java/org/acme/quarkus/sample/HelloResource.java"</li>
+ *   <li>startLine = 16 (line of the text block content of the TemplateContents annotation)</li>
+ * </ul>
+ */
+public interface JavaSourceResolver {
+
+    /**
+     * Resolves the Java method or class referenced from a Qute template for the purpose of setting breakpoints.
+     * <p>
+     * The {@link JavaSourceLocationArguments} contains the parsed information from
+     * a {@code qute-java://} URI. The method returns a {@link CompletableFuture} that
+     * completes with a {@link JavaSourceLocationResponse} containing the Java file URI
+     * and the start line of the template content (or the method/class if applicable).
+     * </p>
+     *
+     * @param args the arguments describing the Java element to resolve
+     * @return a future completing with the resolved Java source location
+     */
+    @JsonRequest("qute/resolveJavaSource")
+    CompletableFuture<JavaSourceLocationResponse> resolveJavaSource(JavaSourceLocationArguments args);
+}

--- a/src/main/java/com/redhat/devtools/intellij/qute/run/client/QuteDAPClient.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/run/client/QuteDAPClient.java
@@ -1,0 +1,227 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.qute.run.client;
+
+import com.intellij.openapi.application.ReadAction;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.*;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.psi.util.ClassUtil;
+import com.intellij.util.concurrency.AppExecutorUtil;
+import com.redhat.devtools.lsp4ij.LSPIJUtils;
+import com.redhat.devtools.lsp4ij.dap.DAPDebugProcess;
+import com.redhat.devtools.lsp4ij.dap.DebugMode;
+import com.redhat.devtools.lsp4ij.dap.client.DAPClient;
+import com.redhat.devtools.lsp4ij.settings.ServerTrace;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * DAP client extension used by Qute to resolve Java source locations
+ * from template-related annotations.
+ * <p>
+ * This client is able to locate the Java source file and the exact
+ * line where a Qute template is defined, based on annotations such as
+ * {@code @CheckedTemplate}.
+ * <p>
+ * The resolution is performed using IntelliJ PSI under a read action
+ * and is safe to run asynchronously.
+ */
+public class QuteDAPClient extends DAPClient implements JavaSourceResolver {
+
+    public QuteDAPClient(@NotNull DAPDebugProcess debugProcess,
+                         @NotNull Map<String, Object> dapParameters,
+                         boolean isDebug,
+                         @NotNull DebugMode debugMode,
+                         @NotNull ServerTrace serverTrace,
+                         @Nullable DAPClient parentClient) {
+        super(debugProcess, dapParameters, isDebug, debugMode, serverTrace, parentClient);
+    }
+
+    /**
+     * Finds the {@link PsiLiteralExpression} associated with the given
+     * annotation.
+     * <p>
+     * The annotation may be declared:
+     * <ul>
+     *   <li>on the class itself</li>
+     *   <li>on a record component (for Java records)</li>
+     *   <li>on a method</li>
+     * </ul>
+     *
+     * @param args    resolution arguments
+     * @param project IntelliJ project
+     * @return the literal expression of the annotation value,
+     * or {@code null} if not found
+     */
+    private static @Nullable PsiLiteralExpression findLiteralExpression(
+            @NotNull JavaSourceLocationArguments args,
+            @NotNull Project project) {
+
+        String typeName = args.getTypeName();
+        String methodName = args.getMethod(); // optional
+        String annotationFqn = args.getAnnotation();
+
+        // Locate the Java class by its fully qualified name
+        PsiClass psiClass = ClassUtil.findPsiClass(
+                PsiManager.getInstance(project),
+                typeName,
+                null,
+                false,
+                GlobalSearchScope.allScope(project)
+        );
+
+        if (psiClass == null) {
+            return null;
+        }
+
+        PsiAnnotation psiAnnotation = null;
+
+        // 1) Annotation declared on the class or record component
+        if (methodName == null) {
+            psiAnnotation = psiClass.getAnnotation(annotationFqn);
+
+            // For records, the annotation may be declared on a component
+            if (psiAnnotation == null && psiClass.isRecord()) {
+                for (PsiRecordComponent component : psiClass.getRecordComponents()) {
+                    PsiAnnotation a = component.getAnnotation(annotationFqn);
+                    if (a != null) {
+                        psiAnnotation = a;
+                        break;
+                    }
+                }
+            }
+        }
+        // 2) Annotation declared on a method
+        else {
+            for (PsiMethod method : psiClass.findMethodsByName(methodName, false)) {
+                PsiAnnotation a = method.getAnnotation(annotationFqn);
+                if (a != null) {
+                    psiAnnotation = a;
+                    break;
+                }
+            }
+        }
+
+        if (psiAnnotation == null) {
+            return null;
+        }
+
+        // Extract the annotation value and ensure it is a literal expression
+        PsiAnnotationMemberValue value =
+                psiAnnotation.getParameterList().getAttributes()[0].getValue();
+
+        if (value instanceof PsiLiteralExpression literal) {
+            return literal;
+        }
+
+        return null;
+    }
+
+    /**
+     * Computes the starting line of the literal content in the source file.
+     * <p>
+     * If the literal is a Java text block ({@code """}), the returned
+     * line corresponds to the first line of the text block content,
+     * excluding the opening delimiter and the following newline.
+     *
+     * @param literal  the literal expression
+     * @param document the document containing the literal
+     * @return the zero-based line number where the content starts
+     */
+    private static int getStartLine(@NotNull PsiLiteralExpression literal,
+                                    @NotNull Document document) {
+
+        TextRange range = literal.getTextRange();
+        String text = literal.getText();
+        int startOffset = range.getStartOffset();
+
+        // Adjust the offset to the start of a text block content
+        int tripleIndex = text.indexOf("\"\"\"");
+        if (tripleIndex != -1) {
+            startOffset = range.getStartOffset() + tripleIndex + 3;
+
+            // Skip the newline immediately following the opening """
+            if (startOffset < document.getTextLength()) {
+                CharSequence chars = document.getCharsSequence();
+                char c = chars.charAt(startOffset);
+
+                if (c == '\n') {
+                    startOffset++;
+                } else if (c == '\r') {
+                    startOffset++;
+                    if (startOffset < document.getTextLength()
+                            && chars.charAt(startOffset) == '\n') {
+                        startOffset++;
+                    }
+                }
+            }
+        }
+
+        return document.getLineNumber(startOffset);
+    }
+
+    /**
+     * Resolves the Java source location corresponding to a Qute-related
+     * annotation.
+     * <p>
+     * The method locates the annotated Java element (class, record
+     * component or method), extracts the annotation literal value
+     * (typically a text block), and computes the line where the
+     * template content starts.
+     *
+     * @param args arguments describing the Java type, method and annotation
+     * @return a future completed with the resolved source location,
+     * or {@code null} if the source cannot be resolved
+     */
+    @Override
+    public @NotNull CompletableFuture<@Nullable JavaSourceLocationResponse> resolveJavaSource(
+            @NotNull JavaSourceLocationArguments args) {
+
+        Project project = getProject();
+        CompletableFuture<JavaSourceLocationResponse> result = new CompletableFuture<>();
+
+        // Run PSI access in a non-blocking read action
+        ReadAction.nonBlocking(() -> {
+
+            // Locate the literal expression from the requested annotation
+            PsiLiteralExpression literal = findLiteralExpression(args, project);
+            if (literal == null) {
+                result.complete(null);
+                return null;
+            }
+
+            // Retrieve the document associated with the Java file
+            PsiFile file = literal.getContainingFile();
+            Document document = PsiDocumentManager.getInstance(project).getDocument(file);
+            if (document == null) {
+                result.complete(null);
+                return null;
+            }
+
+            // Build the response with file URI and start line
+            JavaSourceLocationResponse response = new JavaSourceLocationResponse();
+            response.setJavaFileUri(LSPIJUtils.toUriAsString(file));
+            response.setStartLine(getStartLine(literal, document));
+
+            result.complete(response);
+            return null;
+
+        }).submit(AppExecutorUtil.getAppExecutorService());
+
+        return result;
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -489,6 +489,7 @@
         <lang.substitutor language="yaml"
                           implementationClass="com.redhat.devtools.intellij.qute.lang.QuteLanguageSubstitutor"/>
         <typedHandler implementation="com.redhat.devtools.intellij.qute.editor.QuteTypedHandler"/>
+        <multiHostInjector implementation="com.redhat.devtools.intellij.qute.lang.injector.QuteLanguageInjector"/>
     </extensions>
 
     <extensionPoints>


### PR DESCRIPTION
feat: Qute debugging in Java file

This PR inject Qute template language in `@TemplateContents`, `@Message `

For `@TemplateContents` it uses suffix to set the Qute language to the language declared in sufffix.

<img width="1305" height="408" alt="image" src="https://github.com/user-attachments/assets/e57649e8-ace4-4ea3-9969-1dfb8969c3cf" />

This PR also implements the `resolveJavaSource`  required by the DAP Qute debugger (used to set a breakpoint in Java file and retrieve the proper star line)