### PR TITLE
fix: 2.4.0: java.lang.IllegalArgumentException: port out of range:-1 when trying to run a test

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/qute/run/QuteDebugAdapterDescriptorFactory.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/run/QuteDebugAdapterDescriptorFactory.java
@@ -42,6 +42,6 @@ public class QuteDebugAdapterDescriptorFactory extends DebugAdapterDescriptorFac
     @Override
     public boolean isDebuggableFile(@NotNull VirtualFile file, @NotNull Project project) {
         Language language = LSPIJUtils.getFileLanguage(file, project);
-        return language != null && (QuteLanguage.isQuteLanguage(language) || language.equals(JavaLanguage.INSTANCE));
+        return QuteLanguage.isQuteLanguage(language);
     }
 }


### PR DESCRIPTION
 fix: 2.4.0: java.lang.IllegalArgumentException: port out of range:-1 when trying to run a test

Fixes #1531