### PR TITLE
fix: @ConfigMapping with fields which are same type collect only the first field

### DIFF
--- a/src/main/java/com/redhat/microprofile/psi/internal/quarkus/core/properties/QuarkusConfigMappingProvider.java
+++ b/src/main/java/com/redhat/microprofile/psi/internal/quarkus/core/properties/QuarkusConfigMappingProvider.java
@@ -223,7 +223,7 @@ public class QuarkusConfigMappingProvider extends AbstractAnnotationTypeReferenc
                     // Other type (App interface, etc)
                     Set<PsiClass> allInterfaces = findInterfaces(returnType);
                     for (PsiClass configMappingInterface : allInterfaces) {
-                        populateConfigObject(configMappingInterface, propertyName, extensionName, typesAlreadyProcessed,
+                        populateConfigObject(configMappingInterface, propertyName, extensionName, new HashSet<>(),
                                 configMappingAnnotation, collector);
                     }
                 }


### PR DESCRIPTION
@ConfigMapping with fields which are same type collect only the first field

See https://github.com/redhat-developer/vscode-quarkus/issues/940