### PR TITLE
fix: False Positive: qute(NoMatchingTemplate) error on @CheckedTemplate class when adding a private constructor

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/java/AbstractQuteTemplateLinkCollector.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/internal/java/AbstractQuteTemplateLinkCollector.java
@@ -169,7 +169,9 @@ public abstract class AbstractQuteTemplateLinkCollector extends JavaRecursiveEle
             String basePath = getBasePath(checkedAnnotation);
             TemplateNameStrategy templateNameStrategy = getDefaultName(checkedAnnotation);
             for (PsiMethod method : node.getMethods()) {
-                collectTemplateLinkForMethodOrRecord(basePath, method, method.getName(), node, ignoreFragments, templateNameStrategy);
+                if (!method.isConstructor()) {
+                    collectTemplateLinkForMethodOrRecord(basePath, method, method.getName(), node, ignoreFragments, templateNameStrategy);
+                }
             }
         }
         super.visitClass(node);


### PR DESCRIPTION
fix: False Positive: qute(NoMatchingTemplate) error on @CheckedTemplate class when adding a private constructor

See https://github.com/redhat-developer/vscode-quarkus/issues/1225