### PR TITLE
feat: provide Qute split section parameters settings

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteLanguageSubstitutor.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteLanguageSubstitutor.java
@@ -53,22 +53,20 @@ public class QuteLanguageSubstitutor extends LanguageSubstitutor {
         }
         if (!file.isInLocalFileSystem()) {
             // Ignore non-local file system. This file could come from:
-            // -  JAR archive which is not a Qute template (ex: jar://foo.html)
+            // - JAR archive which is not a Qute template (ex: jar://foo.html)
             // - LightVirtualFile
             return null;
         }
 
-        // Early return: check project-level Qute support (fast, no read action)
+        // Check project-level Qute support (fast, cached)
         if (!hasQuteSupport(project)) {
             return null;
         }
 
-        // Now check module-level (requires read action)
+        // Check module-level support and if file is a Qute template
         Module module = LSPIJUtils.getModule(file, project);
-        if (module != null) {
-            if (hasQuteSupport(module) && isQuteTemplate(file, module)) {
-                return QuteLanguage.INSTANCE;
-            }
+        if (module != null && hasQuteSupport(module) && isQuteTemplate(file, module)) {
+            return QuteLanguage.INSTANCE;
         }
         return null;
     }

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/format/QuteHtmlFormattingModelBuilder.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/format/QuteHtmlFormattingModelBuilder.java
@@ -27,7 +27,7 @@ import static com.intellij.psi.formatter.WrappingUtil.getWrapType;
  * Template aware formatter which provides formatting for Qute syntax and delegates formatting
  * for the templated language to that languages formatter
  * <p>
- * This class is a copy/paste from https://github.com/JetBrains/intellij-plugins/blob/master/Qute/src/com/dmarcotte/Qute/format/HbFormattingModelBuilder.java adapted for Qute.
+ * This class is a copy/paste from <a href="https://github.com/JetBrains/intellij-plugins/blob/master/handlebars/src/com/dmarcotte/Qute/format/HbFormattingModelBuilder.java">HbFormattingModelBuilder.java</a> adapted for Qute.
  */
 public class QuteHtmlFormattingModelBuilder extends TemplateLanguageFormattingModelBuilder {
 

--- a/src/main/java/com/redhat/devtools/intellij/qute/psi/utils/PsiQuteProjectUtils.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/psi/utils/PsiQuteProjectUtils.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package com.redhat.devtools.intellij.qute.psi.utils;
 
-import com.intellij.openapi.application.Application;
+import com.intellij.java.library.JavaLibraryUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
@@ -20,12 +20,16 @@ import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ContentEntry;
 import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.openapi.roots.SourceFolder;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.search.GlobalSearchScope;
-import com.intellij.openapi.roots.PackageIndex;
+import com.intellij.psi.util.CachedValue;
+import com.intellij.psi.util.CachedValueProvider;
+import com.intellij.psi.util.CachedValuesManager;
 import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
+import com.redhat.devtools.intellij.qute.psi.internal.QuteJavaConstants;
 import com.redhat.devtools.intellij.qute.psi.internal.template.rootpath.TemplateRootPathProviderRegistry;
 import com.redhat.devtools.intellij.qute.psi.template.project.ProjectFeatureProviderRegistry;
 import com.redhat.devtools.lsp4ij.LSPIJUtils;
@@ -62,10 +66,8 @@ public class PsiQuteProjectUtils {
      */
     private static final String DEFAULTED = "<<defaulted>>";
 
-    /**
-     * Qute core package name used to detect if Qute is available in the project.
-     */
-    private static final String QUTE_CORE_PACKAGE = "io.quarkus.qute";
+    private static final Key<CachedValue<Boolean>> QUTE_PROJECT_KEY = Key.create("quteProject");
+    private static final Key<CachedValue<Boolean>> QUTE_SUPPORT_KEY = Key.create("quteSupport");
 
     private PsiQuteProjectUtils() {
     }
@@ -74,8 +76,8 @@ public class PsiQuteProjectUtils {
      * Returns true if the given project has Qute support (i.e. at least one module
      * has the Qute library in its dependencies), false otherwise.
      *
-     * <p>This method uses {@link PackageIndex} to check for the presence of the Qute
-     * core package, avoiding the need for explicit read actions and manual cache management.</p>
+     * <p>The result is cached using {@link CachedValuesManager} and invalidated when
+     * project root changes (dependencies added/removed).</p>
      *
      * @param project the project to check, must not be null.
      * @return true if the project has Qute support, false otherwise.
@@ -84,30 +86,25 @@ public class PsiQuteProjectUtils {
         if (project.isDefault()) {
             return false;
         }
-        return PackageIndex.getInstance(project)
-                .getDirectoriesByPackageName(QUTE_CORE_PACKAGE, true).length > 0;
+        CachedValuesManager manager = CachedValuesManager.getManager(project);
+        return manager.getCachedValue(project, QUTE_PROJECT_KEY, () -> {
+            boolean result = false;
+            for (Module m : ModuleManager.getInstance(project).getModules()) {
+                if (hasQuteSupport(m)) {
+                    result = true;
+                    break;
+                }
+            }
+            return CachedValueProvider.Result.create(result, ProjectRootManager.getInstance(project));
+        }, false);
     }
 
     /**
      * Returns true if the given module has Qute support (i.e. the Qute library is present
      * in its dependencies), false otherwise.
      *
-     * <p>This method uses {@link PackageIndex} to check for the presence of the Qute
-     * core package in the module's scope, avoiding the need for explicit read actions
-     * and manual cache management.</p>
-     *
-     * @param javaProject the module to check, must not be null.
-     * @return true if the module has Qute support, false otherwise.
-     */
-    /**
-     * Returns true if the given module has Qute support (i.e. the Qute library is present
-     * in its dependencies), false otherwise.
-     *
-     * <p>This method uses {@link PackageIndex} to check for the presence of the Qute
-     * core package in the module's scope.</p>
-     *
-     * <p><strong>Note:</strong> This method requires a read action to access the module scope.
-     * For quick checks without read action, use {@link #hasQuteSupport(Project)} instead.</p>
+     * <p>The result is cached using {@link CachedValuesManager} and invalidated when
+     * module dependencies change.</p>
      *
      * @param javaProject the module to check, must not be null.
      * @return true if the module has Qute support, false otherwise.
@@ -116,27 +113,11 @@ public class PsiQuteProjectUtils {
         if (javaProject == null || javaProject.getProject().isDefault()) {
             return false;
         }
-
-        if (!ApplicationManager.getApplication().isReadAccessAllowed()) {
-            // Read action is not allowed, check if project has Qute support
-            return hasQuteSupport(javaProject.getProject());
-        }
-
-        VirtualFile[] dirs = PackageIndex.getInstance(javaProject.getProject())
-                .getDirectoriesByPackageName(QUTE_CORE_PACKAGE, true);
-
-        if (dirs.length == 0) {
-            return false;
-        }
-
-        // Check if any directory is in the module's scope
-        GlobalSearchScope scope = GlobalSearchScope.moduleWithDependenciesAndLibrariesScope(javaProject);
-        for (VirtualFile dir : dirs) {
-            if (scope.contains(dir)) {
-                return true;
-            }
-        }
-        return false;
+        CachedValuesManager manager = CachedValuesManager.getManager(javaProject.getProject());
+        return manager.getCachedValue(javaProject, QUTE_SUPPORT_KEY, () -> {
+            boolean result = JavaLibraryUtil.hasAnyLibraryJar(javaProject, QuteJavaConstants.QUTE_MAVEN_COORDS);
+            return CachedValueProvider.Result.create(result, ProjectRootManager.getInstance(javaProject.getProject()));
+        }, false);
     }
 
     public static ProjectInfo getProjectInfo(@NotNull Module javaProject) {

--- a/src/main/java/com/redhat/devtools/intellij/qute/settings/QuteConfigurable.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/settings/QuteConfigurable.java
@@ -66,13 +66,17 @@ public class QuteConfigurable extends NamedConfigurable<UserDefinedQuteSettings>
         if (myView == null) return;
         UserDefinedQuteSettings settings = UserDefinedQuteSettings.getInstance(project);
         myView.setNativeModeSupportEnabled(settings.isNativeModeSupportEnabled());
+        myView.setSplitSectionParameters(settings.getSplitSectionParameters());
+        myView.setSplitSectionParametersIndentSize(settings.getSplitSectionParametersIndentSize());
     }
 
     @Override
     public boolean isModified() {
         if (myView == null) return false;
         UserDefinedQuteSettings settings = UserDefinedQuteSettings.getInstance(project);
-        return myView.isNativeModeSupportEnabled() != settings.isNativeModeSupportEnabled();
+        return myView.isNativeModeSupportEnabled() != settings.isNativeModeSupportEnabled()
+                || myView.getSplitSectionParameters() != settings.getSplitSectionParameters()
+                || myView.getSplitSectionParametersIndentSize() != settings.getSplitSectionParametersIndentSize();
     }
 
     @Override
@@ -80,6 +84,8 @@ public class QuteConfigurable extends NamedConfigurable<UserDefinedQuteSettings>
         if (myView == null) return;
         UserDefinedQuteSettings settings = UserDefinedQuteSettings.getInstance(project);
         settings.setNativeModeSupportEnabled(myView.isNativeModeSupportEnabled());
+        settings.setSplitSectionParameters(myView.getSplitSectionParameters());
+        settings.setSplitSectionParametersIndentSize(myView.getSplitSectionParametersIndentSize());
         settings.fireStateChanged();
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/settings/QuteView.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/settings/QuteView.java
@@ -14,11 +14,14 @@
 package com.redhat.devtools.intellij.qute.settings;
 
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.ui.ComboBox;
 import com.intellij.ui.components.JBCheckBox;
+import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.FormBuilder;
 import com.intellij.util.ui.JBUI;
 import com.redhat.devtools.lsp4ij.ui.components.InspectionHyperlink;
 import com.redhat.devtools.intellij.qute.QuteBundle;
+import com.redhat.qute.settings.QuteFormattingSettings;
 
 import javax.swing.*;
 
@@ -30,6 +33,8 @@ public class QuteView implements Disposable {
     private final JPanel myMainPanel;
 
     private JBCheckBox nativeModeSupportEnabledCheckBox = new JBCheckBox(QuteBundle.message("qute.setting.validation.native.enabled"));
+    private ComboBox<QuteFormattingSettings.SplitSectionParameters> splitSectionParametersComboBox;
+    private JBTextField splitSectionParametersIndentSizeField;
 
     public QuteView() {
         this.myMainPanel = JBUI.Panels.simplePanel(10,10)
@@ -37,9 +42,16 @@ public class QuteView implements Disposable {
     }
 
     private JPanel createSettings() {
+        splitSectionParametersComboBox = new ComboBox<>(QuteFormattingSettings.SplitSectionParameters.values());
+        splitSectionParametersIndentSizeField = new JBTextField();
+        splitSectionParametersIndentSizeField.setColumns(5);
+
         return FormBuilder.createFormBuilder()
                 .addComponent(new InspectionHyperlink(QuteBundle.message("qute.inspection.link"), "Qute"))
                 .addComponent(nativeModeSupportEnabledCheckBox)
+                .addSeparator()
+                .addLabeledComponent("Split section parameters:", splitSectionParametersComboBox)
+                .addLabeledComponent("Indent size:", splitSectionParametersIndentSizeField)
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
     }
@@ -59,5 +71,25 @@ public class QuteView implements Disposable {
 
     public void setNativeModeSupportEnabled(boolean enabled) {
         nativeModeSupportEnabledCheckBox.setSelected(enabled);
+    }
+
+    public QuteFormattingSettings.SplitSectionParameters getSplitSectionParameters() {
+        return (QuteFormattingSettings.SplitSectionParameters) splitSectionParametersComboBox.getSelectedItem();
+    }
+
+    public void setSplitSectionParameters(QuteFormattingSettings.SplitSectionParameters splitSectionParameters) {
+        splitSectionParametersComboBox.setSelectedItem(splitSectionParameters);
+    }
+
+    public int getSplitSectionParametersIndentSize() {
+        try {
+            return Integer.parseInt(splitSectionParametersIndentSizeField.getText());
+        } catch (NumberFormatException e) {
+            return 2; // default
+        }
+    }
+
+    public void setSplitSectionParametersIndentSize(int indentSize) {
+        splitSectionParametersIndentSizeField.setText(String.valueOf(indentSize));
     }
 }

--- a/src/main/java/com/redhat/devtools/intellij/qute/settings/UserDefinedQuteSettings.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/settings/UserDefinedQuteSettings.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.util.containers.ContainerUtil;
 import com.intellij.util.xmlb.annotations.Tag;
 import com.redhat.devtools.lsp4ij.features.diagnostics.SeverityMapping;
+import com.redhat.qute.settings.QuteFormattingSettings;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -152,6 +153,12 @@ public class UserDefinedQuteSettings implements PersistentStateComponent<UserDef
         //Native mode support
         qute.put("native", Collections.singletonMap("enabled", isNativeModeSupportEnabled()));
 
+        // Formatting
+        Map<String, Object> format = new HashMap<>();
+        qute.put("format", format);
+        format.put("splitSectionParameters", getSplitSectionParameters().name());
+        format.put("splitSectionParametersIndentSize", getSplitSectionParametersIndentSize());
+
         // Validation
         Map<String, Object> validation = new HashMap<>();
         qute.put("validation", validation);
@@ -177,6 +184,26 @@ public class UserDefinedQuteSettings implements PersistentStateComponent<UserDef
         myState.myNativeModeSupportEnabled = nativeModeSupportEnabled;
     }
 
+    public QuteFormattingSettings.SplitSectionParameters getSplitSectionParameters() {
+        try {
+            return QuteFormattingSettings.SplitSectionParameters.valueOf(myState.mySplitSectionParameters);
+        } catch (IllegalArgumentException e) {
+            return QuteFormattingSettings.SplitSectionParameters.preserve;
+        }
+    }
+
+    public void setSplitSectionParameters(QuteFormattingSettings.SplitSectionParameters splitSectionParameters) {
+        myState.mySplitSectionParameters = splitSectionParameters.name();
+    }
+
+    public int getSplitSectionParametersIndentSize() {
+        return myState.mySplitSectionParametersIndentSize;
+    }
+
+    public void setSplitSectionParametersIndentSize(int splitSectionParametersIndentSize) {
+        myState.mySplitSectionParametersIndentSize = splitSectionParametersIndentSize;
+    }
+
     public static class MyState {
 
         @Tag("validationEnabled")
@@ -184,6 +211,12 @@ public class UserDefinedQuteSettings implements PersistentStateComponent<UserDef
 
         @Tag("nativeModeSupportEnabled")
         public boolean myNativeModeSupportEnabled;
+
+        @Tag("splitSectionParameters")
+        public String mySplitSectionParameters = QuteFormattingSettings.SplitSectionParameters.preserve.name();
+
+        @Tag("splitSectionParametersIndentSize")
+        public int mySplitSectionParametersIndentSize = 2;
 
         MyState() {
         }


### PR DESCRIPTION
feat: provide Qute split section parameters settings

This PR provides this (basic) UI: 
<img width="1075" height="428" alt="image" src="https://github.com/user-attachments/assets/5e98cf00-5357-4089-9fb1-ee3ae6f2843f" />

Those settings (with split) are used today only with completion.By default it is preserver. 

Here a demo:


<img width="939" height="488" alt="QuteSplitSettingsDemo" src="https://github.com/user-attachments/assets/a0717c9f-e8d0-4afd-8967-60dbfd829a3b" />
