### PR TITLE
fix: java.lang.Throwable: Slow operations are prohibited on EDT with Quarkus Run config

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/BuildToolDelegate.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/BuildToolDelegate.java
@@ -13,13 +13,18 @@ package com.redhat.devtools.intellij.quarkus.buildtool;
 import com.intellij.execution.Executor;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.openapi.extensions.ExtensionPointName;
+import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleGrouper;
+import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.JarFileSystem;
 import com.intellij.openapi.vfs.LocalFileSystem;
+import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.util.messages.MessageBusConnection;
+import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
 import com.redhat.devtools.intellij.quarkus.run.QuarkusRunConfiguration;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -36,7 +41,38 @@ import static com.redhat.devtools.intellij.quarkus.QuarkusConstants.QUARKUS_EXTE
 
 public interface BuildToolDelegate {
 
-    static boolean shouldResolveArtifactTransitively(MavenId deploymentId) {
+    static @Nullable String getModuleDirPath(@NotNull Module module) {
+        return getModuleDirPath(module, null);
+    }
+
+    static @Nullable String getModuleDirPath(@NotNull Module module, @Nullable String scriptName) {
+        String modulePath = ExternalSystemApiUtil.getExternalProjectPath(module);
+        if (modulePath != null) {
+            return modulePath;
+        }
+
+        VirtualFile dir = QuarkusModuleUtil.getModuleDirPath(module);
+        if (scriptName == null) {
+            return dir != null ? VfsUtilCore.virtualToIoFile(dir).getAbsolutePath() : null;
+        }
+
+        VirtualFile script = dir != null ? dir.findChild(scriptName) : null;
+        if (script != null && script.exists()) {
+            return dir.getPath();
+        }
+        ModuleGrouper grouper = ModuleGrouper.instanceFor(module.getProject());
+        List<String> names = grouper.getGroupPath(module);
+        if (!names.isEmpty()) {
+            ModuleManager manager = ModuleManager.getInstance(module.getProject());
+            Module parentModule = manager.findModuleByName(names.get(0));
+            if (parentModule != null) {
+                return getModuleDirPath(parentModule, scriptName);
+            }
+        }
+        return null;
+    }
+
+    static boolean shouldResolveArtifactTransitively(@NotNull MavenId deploymentId) {
         // The kubernetes support is only available if quarkus-kubernetes artifact is
         // declared in the pom.xml
         // When quarkus-kubernetes is declared, this JAR declares the deployment JAR
@@ -53,7 +89,7 @@ public interface BuildToolDelegate {
                 || "quarkus-smallrye-openapi-deployment".equals(deploymentId.getArtifactId());
     }
 
-    static String getDeploymentJarId(File file) {
+    static String getDeploymentJarId(@NotNull File file) {
         String result = null;
         if (file.isDirectory()) {
             File quarkusFile = new File(file, QUARKUS_EXTENSION_PROPERTIES);
@@ -65,7 +101,7 @@ public interface BuildToolDelegate {
                 }
             }
         } else {
-            try(JarFile jarFile = new JarFile(file)) {
+            try (JarFile jarFile = new JarFile(file)) {
                 JarEntry entry = jarFile.getJarEntry(QUARKUS_EXTENSION_PROPERTIES);
                 if (entry != null) {
                     try (Reader r = new InputStreamReader(jarFile.getInputStream(entry), StandardCharsets.UTF_8)) {
@@ -79,17 +115,17 @@ public interface BuildToolDelegate {
         return result;
     }
 
-    static boolean hasExtensionProperties(File file) {
+    static boolean hasExtensionProperties(@NotNull File file) {
         return getDeploymentJarId(file) != null;
     }
 
-    static String getQuarkusExtension(Reader r) throws IOException {
+    static String getQuarkusExtension(@NotNull Reader r) throws IOException {
         Properties p = new Properties();
         p.load(r);
         return p.getProperty(QUARKUS_DEPLOYMENT_PROPERTY_NAME);
     }
 
-    static BuildToolDelegate getDelegate(Module module) {
+    static BuildToolDelegate getDelegate(@NotNull Module module) {
         for (BuildToolDelegate toolDelegate : getDelegates()) {
             if (toolDelegate.isValid(module)) {
                 return toolDelegate;
@@ -114,12 +150,14 @@ public interface BuildToolDelegate {
      * Return the list of additional deployment JARs for the module. The array should have 2 elements, the first
      * one being for binary JARs, the second one for sources JARs.
      *
-     * @param module the module to process
+     * @param module            the module to process
+     * @param progressIndicator the progress indicator
      * @return the list of additional deployment JARs for the module
      * @see #BINARY
      * @see #SOURCES
      */
-    List<VirtualFile>[] getDeploymentFiles(Module module, ProgressIndicator progressIndicator);
+    List<VirtualFile>[] getDeploymentFiles(@NotNull Module module,
+                                           @NotNull ProgressIndicator progressIndicator);
 
     /**
      * Returns the displayable string for the delegate.
@@ -157,7 +195,7 @@ public interface BuildToolDelegate {
         return getJarFile(new File(path));
     }
 
-    default VirtualFile getJarFile(File file) {
+    default VirtualFile getJarFile(@NotNull File file) {
         VirtualFile virtualFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(file);
         return virtualFile != null ? JarFileSystem.getInstance().getJarRootForLocalFile(virtualFile) : null;
     }

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/AbstractGradleToolDelegate.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/AbstractGradleToolDelegate.java
@@ -73,7 +73,7 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
 
     private static final String GRADLE_LIBRARY_PREFIX = "Gradle: ";
 
-    private boolean scriptExists(Module module) {
+    private boolean scriptExists(@NotNull Module module) {
         String path = getModuleDirPath(module);
         if (path != null) {
             File script = new File(path, getScriptName());
@@ -83,21 +83,24 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
     }
 
     @Override
-    public boolean isValid(Module module) {
+    public boolean isValid(@NotNull Module module) {
         return ExternalSystemApiUtil.isExternalSystemAwareModule(GradleConstants.SYSTEM_ID, module) && scriptExists(module);
     }
 
     @Override
-    public List<VirtualFile>[] getDeploymentFiles(Module module, ProgressIndicator progressIndicator) {
+    public List<VirtualFile>[] getDeploymentFiles(@NotNull Module module,
+                                                  @NotNull ProgressIndicator progressIndicator) {
         List<VirtualFile>[] result = BuildToolDelegate.initDeploymentFiles();
         ModuleRootManager manager = ModuleRootManager.getInstance(module);
         Set<String> deploymentIds = new HashSet<>();
         try {
             manager.orderEntries().forEachLibrary(library -> {
+                progressIndicator.checkCanceled();
                 processLibrary(library, manager, deploymentIds);
                 return true;
             });
             if (!deploymentIds.isEmpty()) {
+                progressIndicator.checkCanceled();
                 processDownload(module, deploymentIds, result);
             }
         } catch (IOException e) {
@@ -114,7 +117,9 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
      * @param result        the list where to place results to
      * @throws IOException if an error occurs running Gradle
      */
-    private void processDownload(Module module, Set<String> deploymentIds, List<VirtualFile>[] result) throws IOException {
+    private void processDownload(@NotNull Module module,
+                                 @NotNull Set<String> deploymentIds,
+                                 @NotNull List<VirtualFile>[] result) throws IOException {
         Path outputPath = Files.createTempFile(null, ".txt");
         Path customBuildFile = generateCustomGradleBuild(getModuleDirPath(module), outputPath, deploymentIds);
         Path customSettingsFile = generateCustomGradleSettings(getModuleDirPath(module), customBuildFile);
@@ -149,23 +154,8 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
         }
     }
 
-
-    private String getModuleDirPath(Module module) {
-        VirtualFile dir = QuarkusModuleUtil.getModuleDirPath(module);
-        VirtualFile script = dir != null ? dir.findChild(getScriptName()) : null;
-        if (script != null && script.exists()) {
-            return dir.getPath();
-        }
-        ModuleGrouper grouper = ModuleGrouper.instanceFor(module.getProject());
-        List<String> names = grouper.getGroupPath(module);
-        if (!names.isEmpty()) {
-            ModuleManager manager = ModuleManager.getInstance(module.getProject());
-            Module parentModule = manager.findModuleByName(names.get(0));
-            if (parentModule != null) {
-                return getModuleDirPath(parentModule);
-            }
-        }
-        return null;
+    private @Nullable String getModuleDirPath(Module module) {
+        return BuildToolDelegate.getModuleDirPath(module, getScriptName());
     }
 
     /**
@@ -177,7 +167,11 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
      * @param callback   the callback to call after running the task
      * @throws IOException if an error occurs running Gradle
      */
-    private void collectDependencies(Module module, Path customSettingsFile, Path outputPath, List<VirtualFile>[] result, TaskCallback callback) throws IOException {
+    private void collectDependencies(@NotNull Module module,
+                                     @NotNull Path customSettingsFile,
+                                     @NotNull Path outputPath,
+                                     @NotNull List<VirtualFile>[] result,
+                                     @NotNull TaskCallback callback) throws IOException {
         try {
             ExternalSystemTaskExecutionSettings executionSettings = new ExternalSystemTaskExecutionSettings();
             executionSettings.setExternalSystemIdString(GradleConstants.SYSTEM_ID.toString());
@@ -377,10 +371,7 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
         RunnerAndConfigurationSettings settings = RunManager.getInstance(module.getProject()).createConfiguration(module.getName() + " Quarkus (Gradle)", GradleExternalTaskConfigurationType.class);
         GradleRunConfiguration gradleConfiguration = (GradleRunConfiguration) settings.getConfiguration();
         gradleConfiguration.getSettings().getTaskNames().add("quarkusDev");
-        String externalProjectPath = ExternalSystemApiUtil.getExternalProjectPath(module);
-        if (externalProjectPath == null) {
-            externalProjectPath = getModuleDirPath(module);
-        }
+        String externalProjectPath = getModuleDirPath(module);
         gradleConfiguration.getSettings().setExternalProjectPath(externalProjectPath);
         gradleConfiguration.getSettings().setEnv(configuration.getEnv());
         String parameters = createParameters(configuration, debugPort, quteDebugPort);

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/maven/MavenToolDelegate.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/maven/MavenToolDelegate.java
@@ -14,6 +14,7 @@ import com.intellij.execution.RunManager;
 import com.intellij.execution.RunnerAndConfigurationSettings;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.DumbAwareRunnable;
 import com.intellij.openapi.project.Project;
@@ -56,7 +57,7 @@ public class MavenToolDelegate implements BuildToolDelegate {
     }
 
     @Override
-    public List<VirtualFile>[] getDeploymentFiles(Module module, ProgressIndicator progressIndicator) {
+    public List<VirtualFile>[] getDeploymentFiles(@NotNull Module module, @NotNull ProgressIndicator progressIndicator) {
         MavenProject mavenProject = MavenProjectsManager.getInstance(module.getProject()).findProject(module);
         List<VirtualFile>[] result = BuildToolDelegate.initDeploymentFiles();
         if (mavenProject != null) {
@@ -81,7 +82,10 @@ public class MavenToolDelegate implements BuildToolDelegate {
 
     }
 
-    private void getDeploymentFiles(Module module, MavenProject mavenProject, List<VirtualFile>[] result, ProgressIndicator progressIndicator) {
+    private void getDeploymentFiles(@NotNull Module module,
+                                    @NotNull MavenProject mavenProject,
+                                    @NotNull List<VirtualFile>[] result,
+                                    @NotNull ProgressIndicator progressIndicator) {
         Set<MavenArtifact> downloaded = new HashSet<>();
         Set<MavenId> toDownload = new HashSet<>();
 
@@ -179,6 +183,8 @@ public class MavenToolDelegate implements BuildToolDelegate {
                     }
                 }
             }
+        }catch(ProcessCanceledException e) {
+            throw e;
         } catch (Exception e) {
             LOGGER.warn(e.getLocalizedMessage(), e);
         }
@@ -192,14 +198,15 @@ public class MavenToolDelegate implements BuildToolDelegate {
     }
 
     @Override
-    public RunnerAndConfigurationSettings getConfigurationDelegate(@NotNull Module module, @NotNull QuarkusRunConfiguration configuration,
+    public RunnerAndConfigurationSettings getConfigurationDelegate(@NotNull Module module,
+                                                                   @NotNull QuarkusRunConfiguration configuration,
                                                                    @Nullable Integer debugPort,
                                                                    @Nullable Integer quteDebugPort) {
         RunnerAndConfigurationSettings settings = RunManager.getInstance(module.getProject()).createConfiguration(module.getName() + " Quarkus (Maven)", MavenRunConfigurationType.class);
         MavenRunConfiguration mavenConfiguration = (MavenRunConfiguration) settings.getConfiguration();
         mavenConfiguration.getRunnerParameters().setResolveToWorkspace(true);
         mavenConfiguration.getRunnerParameters().setGoals(Collections.singletonList("quarkus:dev"));
-        mavenConfiguration.getRunnerParameters().setWorkingDirPath(VfsUtilCore.virtualToIoFile(QuarkusModuleUtil.getModuleDirPath(module)).getAbsolutePath());
+        mavenConfiguration.getRunnerParameters().setWorkingDirPath(BuildToolDelegate.getModuleDirPath(module));
         ensureRunnerSettings(mavenConfiguration);
         mavenConfiguration.getRunnerSettings().setEnvironmentProperties(configuration.getEnv());
         if (StringUtils.isNotBlank(configuration.getProfile())) {

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/run/QuarkusRunConfiguration.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/run/QuarkusRunConfiguration.java
@@ -16,10 +16,12 @@ import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.runners.ExecutionEnvironmentBuilder;
 import com.intellij.execution.runners.RunConfigurationWithSuppressedDefaultRunAction;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
+import com.intellij.util.SlowOperations;
 import com.intellij.util.net.NetUtils;
 import com.redhat.devtools.intellij.quarkus.QuarkusModuleUtil;
 import com.redhat.devtools.intellij.quarkus.buildtool.BuildToolDelegate;
@@ -157,7 +159,9 @@ public class QuarkusRunConfiguration extends ModuleBasedConfiguration<RunConfigu
         // We check if "io.quarkus.qute.runtime.debug.DebugQuteEngineObserver" is in the classpath
         // Note: we cannot check if "io.quarkus.qute.debug.adapter.RegisterDebugServerAdapter" is in classpath
         // because "io.quarkus.qute.debug.adapter.RegisterDebugServerAdapter" is not available in the standard IJ classpath
-        return PsiTypeUtils.findType("io.quarkus.qute.runtime.debug.DebugQuteEngineObserver", module, null) != null;
+        return SlowOperations.allowSlowOperations(() ->
+            PsiTypeUtils.findType("io.quarkus.qute.runtime.debug.DebugQuteEngineObserver", module, null) != null
+        );
     }
 
     public String getProfile() {


### PR DESCRIPTION
fix: java.lang.Throwable: Slow operations are prohibited on EDT with Quarkus Run config

Fixes #1598