### PR TITLE
feat: Qute Syntax coloration for alt syntax expression

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteParserDefinition.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/QuteParserDefinition.java
@@ -34,7 +34,7 @@ public class QuteParserDefinition implements ParserDefinition {
 
     @Override
     public @NotNull Lexer createLexer(@NotNull Project project) {
-        return new QuteLexer(project);
+        return new QuteLexer(null, project);
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/highlighter/QuteSyntaxHighlighter.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/highlighter/QuteSyntaxHighlighter.java
@@ -91,6 +91,7 @@ public class QuteSyntaxHighlighter extends SyntaxHighlighterBase {
 
     private final @Nullable Module module;
     private final @Nullable Project project;
+    private final @Nullable VirtualFile virtualFile;
 
     public QuteSyntaxHighlighter() {
         this(null, null);
@@ -98,6 +99,7 @@ public class QuteSyntaxHighlighter extends SyntaxHighlighterBase {
 
     public QuteSyntaxHighlighter(@Nullable VirtualFile virtualFile, @Nullable Project project) {
         this.project = project;
+        this.virtualFile = virtualFile;
         if (virtualFile != null && project != null) {
             this.module = LSPIJUtils.getModule(virtualFile, project);
         } else {
@@ -108,10 +110,10 @@ public class QuteSyntaxHighlighter extends SyntaxHighlighterBase {
     @Override
     public @NotNull Lexer getHighlightingLexer() {
         if (module != null) {
-            return new QuteLexer(module);
+            return new QuteLexer(virtualFile, module);
         }
         if (project != null) {
-            return new QuteLexer(project);
+            return new QuteLexer(virtualFile, project);
         }
         return new QuteLexer();
     }

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/psi/QuteLexer.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/psi/QuteLexer.java
@@ -12,10 +12,13 @@ package com.redhat.devtools.intellij.qute.lang.psi;
 
 import com.intellij.lexer.LexerBase;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Key;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.tree.IElementType;
-import com.redhat.devtools.intellij.qute.psi.internal.extensions.roq.RoqUtils;
+import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.project.PsiMicroProfileProjectManager;
 import com.redhat.qute.parser.injection.InjectionDetector;
 import com.redhat.qute.parser.template.scanner.ScannerState;
 import com.redhat.qute.parser.template.scanner.TemplateScanner;
@@ -35,9 +38,15 @@ import static com.redhat.devtools.intellij.qute.psi.internal.extensions.roq.RoqU
  */
 public class QuteLexer extends LexerBase {
 
+    /**
+     * UserData key to force alt-expr-syntax mode for testing purposes.
+     * When set to true in Project.getUserData(), the lexer will use {=...} syntax.
+     */
+    public static final Key<Boolean> FORCE_ALT_EXPR_SYNTAX = Key.create("qute.force.alt.expr.syntax");
+
     public static final List<InjectionDetector> YAML_FRONT_MATTER_DETECTORS = Collections.singletonList(new YamlFrontMatterDetector());
     private final Collection<InjectionDetector> injectors;
-    private final Character expressionCommand = null;
+    private final Character expressionCommand;
     private IElementType myTokenType;
     private CharSequence myText;
 
@@ -57,12 +66,69 @@ public class QuteLexer extends LexerBase {
     private int startTagOpenOffset;
     private int startLanguageInjectionOffset;
 
-    public QuteLexer(@NotNull Module module) {
-        this(isRoqProject(module));
+    public QuteLexer(@Nullable VirtualFile file, @NotNull Module module) {
+        this(isRoqProject(module), isAltExprSyntax(file, module));
     }
 
-    public QuteLexer(@NotNull Project project) {
-        this(isRoqProject(project));
+    public QuteLexer(@Nullable VirtualFile file, @NotNull Project project) {
+        this(isRoqProject(project), isAltExprSyntax(file, getFirstModule(project)));
+    }
+
+    private static @Nullable Module getFirstModule(@NotNull Project project) {
+        var modules = ModuleManager.getInstance(project).getModules();
+        return modules != null && modules.length > 0 ? modules[0] : null;
+    }
+
+    private static boolean isAltExprSyntax(@Nullable VirtualFile file, @Nullable Module module) {
+        if (file == null && module == null){
+            return false;
+        }
+
+        // Check UserData first (for testing purposes)
+        if (module != null) {
+            Boolean forceAltSyntax = module.getProject().getUserData(FORCE_ALT_EXPR_SYNTAX);
+            if (forceAltSyntax != null && forceAltSyntax) {
+                return true;
+            }
+
+            // Check application.properties
+            var mpProject = PsiMicroProfileProjectManager.getInstance(module.getProject()).getMicroProfileProject(module);
+            if (mpProject.getProperty("quarkus.qute.alt-expr-syntax", "false").equals("true")) {
+                return true;
+            }
+        }
+
+        if (file != null) {
+            // Search for .qute file in parent directories
+            return searchAltExprSyntaxInParent(file);
+        }
+        return false;
+    }
+
+    /**
+     * Searches for a {@code .qute} file in the parent directories of the given file
+     * and checks if {@code alt-expr-syntax=true} is set.
+     *
+     * @param file the template file to start searching from.
+     * @return {@code true} if alt-expr-syntax is enabled in a parent .qute file, {@code false} otherwise.
+     */
+    private static boolean searchAltExprSyntaxInParent(@NotNull VirtualFile file) {
+        VirtualFile parent = file.getParent();
+        while (parent != null) {
+            VirtualFile dotQuteFile = parent.findChild(".qute");
+            if (dotQuteFile != null && dotQuteFile.exists() && !dotQuteFile.isDirectory()) {
+                java.util.Properties props = new java.util.Properties();
+                try (java.io.InputStream is = dotQuteFile.getInputStream()) {
+                    props.load(is);
+                    Object result = props.getOrDefault("alt-expr-syntax", false);
+                    return result instanceof Boolean ? (Boolean) result : Boolean.parseBoolean(result.toString());
+                } catch (java.io.IOException e) {
+                    // Ignore and continue searching in parent directories
+                }
+            }
+            parent = parent.getParent();
+        }
+        return false;
     }
 
     public QuteLexer() {
@@ -70,7 +136,12 @@ public class QuteLexer extends LexerBase {
     }
 
     public QuteLexer(boolean roqSupport) {
-        injectors = roqSupport ? YAML_FRONT_MATTER_DETECTORS : Collections.emptyList();
+        this(roqSupport, false);
+    }
+
+    public QuteLexer(boolean roqSupport, boolean altExprSyntax) {
+        this.injectors = roqSupport ? YAML_FRONT_MATTER_DETECTORS : Collections.emptyList();
+        this.expressionCommand = altExprSyntax ? '=' : null;
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/qute/lang/psi/QutePsiFile.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lang/psi/QutePsiFile.java
@@ -13,9 +13,11 @@ package com.redhat.devtools.intellij.qute.lang.psi;
 import com.intellij.extapi.psi.PsiFileBase;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.psi.FileViewProvider;
+import com.intellij.psi.PsiElement;
 import com.redhat.devtools.intellij.qute.lang.QuteFileType;
 import com.redhat.devtools.intellij.qute.lang.QuteLanguage;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Qute Psi file.
@@ -28,5 +30,23 @@ public class QutePsiFile extends PsiFileBase {
     @Override
     public @NotNull FileType getFileType() {
         return QuteFileType.QUTE;
+    }
+
+    @Override
+    public @Nullable PsiElement findElementAt(int offset) {
+        // For template language files with TemplateLanguageFileViewProvider,
+        // we need to search in the Qute language tree, not the template data language tree
+        FileViewProvider viewProvider = getViewProvider();
+
+        // First, try to find element in Qute language
+        PsiElement quteElement = viewProvider.findElementAt(offset, QuteLanguage.INSTANCE);
+
+        // If found in Qute tree, return it
+        if (quteElement != null) {
+            return quteElement;
+        }
+
+        // Otherwise, fallback to default behavior (template data language like HTML)
+        return super.findElementAt(offset);
     }
 }

--- a/src/test/java/com/redhat/devtools/intellij/qute/lang/psi/QutePsiFileFindElementAtAltSyntaxTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/qute/lang/psi/QutePsiFileFindElementAtAltSyntaxTest.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.intellij.qute.lang.psi;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.redhat.devtools.intellij.qute.lang.QuteASTObjectPart;
+import com.redhat.devtools.intellij.qute.lang.QuteASTPropertyPart;
+import com.redhat.devtools.intellij.qute.lang.QuteFileType;
+
+/**
+ * Tests for {@link QutePsiFile#findElementAt(int)} with alternative expression syntax.
+ * <p>
+ * Alternative syntax uses {=...} instead of {...} for Qute expressions.
+ * <p>
+ * These tests use {@link QuteLexer#FORCE_ALT_EXPR_SYNTAX} UserData key to enable
+ * alt-expr-syntax in the test environment.
+ */
+public class QutePsiFileFindElementAtAltSyntaxTest extends BasePlatformTestCase {
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        // Enable alt-expr-syntax via UserData (workaround for testing)
+        getProject().putUserData(QuteLexer.FORCE_ALT_EXPR_SYNTAX, true);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            // Clean up UserData
+            getProject().putUserData(QuteLexer.FORCE_ALT_EXPR_SYNTAX, null);
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    public void testFindElementAt_AlternativeSyntax_SimpleObjectPart() {
+        // Test with alternative syntax: {=item}
+        PsiFile file = myFixture.configureByText(QuteFileType.QUTE, "{=item}");
+
+        System.out.println("\n=== Analyzing {=item} (alt syntax) ===");
+        System.out.println("File class: " + file.getClass().getName());
+        System.out.println("File language: " + file.getLanguage());
+        System.out.println("File virtual file: " + file.getVirtualFile());
+
+        // Find element at 'i' in {=item} (offset 2 because of '=' at offset 1)
+        PsiElement element = file.findElementAt(2);
+
+        assertNotNull("Element should not be null", element);
+
+        // Print debug info
+        printElementDebugInfo("Alt syntax object (offset 2)", element);
+
+        // Verify it's a QuteASTObjectPart or its child
+        boolean isQuteElement = element instanceof QuteASTObjectPart
+                || element.getParent() instanceof QuteASTObjectPart;
+
+        if (!isQuteElement) {
+            System.out.println("\n⚠️  Alt-expr-syntax not detected:");
+            System.out.println("   Expected: QuteASTObjectPart");
+            System.out.println("   Actual: " + element.getClass().getName());
+            System.out.println("   This means application.properties was not read by PsiMicroProfileProjectManager");
+        }
+
+        assertTrue("Element should be QuteASTObjectPart or its child, but was: " + element.getClass().getName(),
+                isQuteElement);
+    }
+
+    public void testFindElementAt_AlternativeSyntax_PropertyPart() {
+        PsiFile file = myFixture.configureByText(QuteFileType.QUTE, "{=item.name}");
+
+        PsiElement element = file.findElementAt(7);
+        assertNotNull("Element should not be null", element);
+
+        printElementDebugInfo("Alt syntax property (offset 7)", element);
+
+        // Verify it's a QuteASTPropertyPart or its child
+        boolean isQuteElement = element instanceof QuteASTPropertyPart
+                || element.getParent() instanceof QuteASTPropertyPart;
+        assertTrue("Element should be QuteASTPropertyPart or its child, but was: " + element.getClass().getName(),
+                isQuteElement);
+    }
+
+    public void testFindElementAt_AlternativeSyntax_NamespacedObjectPart() {
+        PsiFile file = myFixture.configureByText(QuteFileType.QUTE, "{=uri:item}");
+
+        PsiElement element = file.findElementAt(6);
+        assertNotNull("Element should not be null", element);
+
+        printElementDebugInfo("Alt syntax namespace (offset 6)", element);
+
+        // Verify it's a QuteASTObjectPart or its child
+        boolean isQuteElement = element instanceof QuteASTObjectPart
+                || element.getParent() instanceof QuteASTObjectPart;
+        assertTrue("Element should be QuteASTObjectPart or its child, but was: " + element.getClass().getName(),
+                isQuteElement);
+    }
+
+    public void testFindElementAt_AlternativeSyntax_WithLetDeclaration() {
+        // Test with let declaration followed by alt-syntax usage
+        // This is a production bug: can't find 'foo' in {=foo.blank.is(true)}
+        String content = "{@java.lang.String foo}\n{=foo.blank.is(true)}";
+        PsiFile file = myFixture.configureByText(QuteFileType.QUTE, content);
+
+        System.out.println("\n=== Analyzing alt-syntax with let declaration ===");
+        System.out.println("Content:\n" + content);
+
+        // Find 'foo' in {=foo.blank.is(true)}
+        // Position: "{@java.lang.String foo}\n{=foo.blank.is(true)}"
+        //            012345678901234567890123 24 252627282930...
+        int fooOffset = content.indexOf("{=foo") + 2; // Position of 'f' in {=foo
+
+        System.out.println("Looking for 'foo' at offset: " + fooOffset);
+        System.out.println("Character at offset: '" + content.charAt(fooOffset) + "'");
+
+        PsiElement element = file.findElementAt(fooOffset);
+        assertNotNull("Element should not be null", element);
+
+        printElementDebugInfo("Alt syntax 'foo' after let declaration (offset " + fooOffset + ")", element);
+
+        // Verify it's a QuteASTObjectPart (foo) or its child
+        boolean isQuteElement = element instanceof QuteASTObjectPart
+                || element.getParent() instanceof QuteASTObjectPart;
+
+        if (!isQuteElement) {
+            System.out.println("\n❌ BUG REPRODUCED:");
+            System.out.println("   Expected: QuteASTObjectPart for 'foo'");
+            System.out.println("   Actual: " + element.getClass().getName());
+            System.out.println("   This is the production bug we're trying to fix!");
+        }
+
+        assertTrue("Element should be QuteASTObjectPart for 'foo', but was: " + element.getClass().getName(),
+                isQuteElement);
+    }
+
+    private void printElementDebugInfo(String label, PsiElement element) {
+        System.out.println("\n=== " + label + " ===");
+        System.out.println("Element: " + element.getClass().getName() + " = " + element);
+        System.out.println("  Text: '" + element.getText() + "'");
+        System.out.println("  TextRange: " + element.getTextRange());
+        if (element.getNode() != null) {
+            System.out.println("  Node type: " + element.getNode().getElementType());
+        } else {
+            System.out.println("  Node type: null (no AST node)");
+        }
+
+        PsiElement parent = element.getParent();
+        int level = 1;
+        while (parent != null && level <= 5) {
+            String nodeType = parent.getNode() != null
+                    ? parent.getNode().getElementType().toString()
+                    : "null";
+            System.out.println("  Parent[" + level + "]: " + parent.getClass().getName()
+                    + " - " + nodeType
+                    + " - Range: " + parent.getTextRange());
+            parent = parent.getParent();
+            level++;
+        }
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/resources";
+    }
+}

--- a/src/test/java/com/redhat/devtools/intellij/qute/lang/psi/QutePsiFileFindElementAtTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/qute/lang/psi/QutePsiFileFindElementAtTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Red Hat Inc. - initial API and implementation
+ *******************************************************************************/
+package com.redhat.devtools.intellij.qute.lang.psi;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import com.redhat.devtools.intellij.qute.lang.QuteASTObjectPart;
+import com.redhat.devtools.intellij.qute.lang.QuteASTPropertyPart;
+import com.redhat.devtools.intellij.qute.lang.QuteFileType;
+
+/**
+ * Tests for {@link QutePsiFile#findElementAt(int)} to verify it returns
+ * the correct Qute PSI elements (QuteASTPart) instead of template language elements.
+ */
+public class QutePsiFileFindElementAtTest extends BasePlatformTestCase {
+
+    public void testFindElementAt_SimpleObjectPart() {
+        // Test with simple expression: {item}
+        PsiFile file = myFixture.configureByText(QuteFileType.QUTE, "{item}");
+
+        // Find element at 'i' in {item}
+        PsiElement element = file.findElementAt(1);
+
+        assertNotNull("Element should not be null", element);
+
+        // Verify it's a QuteASTObjectPart or its child
+        boolean isQuteElement = element instanceof QuteASTObjectPart
+                || element.getParent() instanceof QuteASTObjectPart;
+        assertTrue("Element should be QuteASTObjectPart or its child, but was: " + element.getClass().getName(),
+                isQuteElement);
+    }
+
+    public void testFindElementAt_PropertyPart() {
+        // Test with property expression: {item.name}
+        PsiFile file = myFixture.configureByText(QuteFileType.QUTE, "{item.name}");
+
+        // Find element at 'n' in {item.name}
+        PsiElement element = file.findElementAt(6);
+
+        assertNotNull("Element should not be null", element);
+
+        // Verify it's a QuteASTPropertyPart or its child
+        boolean isQuteElement = element instanceof QuteASTPropertyPart
+                || element.getParent() instanceof QuteASTPropertyPart;
+        assertTrue("Element should be QuteASTPropertyPart or its child, but was: " + element.getClass().getName(),
+                isQuteElement);
+    }
+
+    public void testFindElementAt_NamespacedObjectPart() {
+        // Test with namespaced expression: {uri:item}
+        PsiFile file = myFixture.configureByText(QuteFileType.QUTE, "{uri:item}");
+
+        // Find element at 'i' in {uri:item}
+        PsiElement element = file.findElementAt(5);
+
+        assertNotNull("Element should not be null", element);
+
+        // Verify it's a QuteASTObjectPart or its child
+        boolean isQuteElement = element instanceof QuteASTObjectPart
+                || element.getParent() instanceof QuteASTObjectPart;
+        assertTrue("Element should be QuteASTObjectPart or its child, but was: " + element.getClass().getName(),
+                isQuteElement);
+    }
+
+    public void testFindElementAt_ComplexExpression() {
+        // Test with complex expression: {uri:item.name}
+        PsiFile file = myFixture.configureByText(QuteFileType.QUTE, "{uri:item.name}");
+
+        // Test at object part
+        PsiElement objectElement = file.findElementAt(5); // 'i' in item
+        assertNotNull("Object element should not be null", objectElement);
+
+        // Test at property part
+        PsiElement propertyElement = file.findElementAt(10); // 'n' in name
+        assertNotNull("Property element should not be null", propertyElement);
+    }
+
+    public void testFindElementAt_HTMLContent() {
+        // Test with HTML content outside Qute expressions
+        PsiFile file = myFixture.configureByText(QuteFileType.QUTE, "<h1>Hello {name}!</h1>");
+
+        // Find element at 'H' in <h1>
+        PsiElement htmlElement = file.findElementAt(1);
+        assertNotNull("HTML element should not be null", htmlElement);
+
+        // Find element at 'n' in {name}
+        PsiElement quteElement = file.findElementAt(13);
+        assertNotNull("Qute element should not be null", quteElement);
+    }
+
+    @Override
+    protected String getTestDataPath() {
+        return "src/test/resources";
+    }
+}

--- a/testData/qute/psi/FindElementAt_AlternativeSyntax_ComplexExpression.txt
+++ b/testData/qute/psi/FindElementAt_AlternativeSyntax_ComplexExpression.txt
@@ -1,0 +1,13 @@
+QUTE_FILE
+  ASTWrapperPsiElement(QuteElementType.QUTE_CONTENT)
+    ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION)
+      PsiElement(QuteElementType.QUTE_START_EXPRESSION)('{=')
+      ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION_NAMESPACE_PART)
+        PsiElement(QuteElementType.QUTE_EXPRESSION_NAMESPACE_PART)('uri')
+      PsiElement(QuteElementType.QUTE_EXPRESSION_COLON_SPACE)(':')
+      ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION_OBJECT_PART)
+        PsiElement(QuteElementType.QUTE_EXPRESSION_OBJECT_PART)('item')
+      PsiElement(QuteElementType.QUTE_EXPRESSION_DOT)('.')
+      ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION_PROPERTY_PART)
+        PsiElement(QuteElementType.QUTE_EXPRESSION_PROPERTY_PART)('name')
+      PsiElement(QuteElementType.QUTE_END_EXPRESSION)('}')

--- a/testData/qute/psi/FindElementAt_AlternativeSyntax_HTMLContent.txt
+++ b/testData/qute/psi/FindElementAt_AlternativeSyntax_HTMLContent.txt
@@ -1,0 +1,11 @@
+QUTE_FILE
+  ASTWrapperPsiElement(QuteElementType.QUTE_CONTENT)
+    ASTWrapperPsiElement(QUTE_TEXT)
+      PsiElement(QUTE_TEXT)('<h1>Hello ')
+    ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION)
+      PsiElement(QuteElementType.QUTE_START_EXPRESSION)('{=')
+      ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION_OBJECT_PART)
+        PsiElement(QuteElementType.QUTE_EXPRESSION_OBJECT_PART)('name')
+      PsiElement(QuteElementType.QUTE_END_EXPRESSION)('}')
+    ASTWrapperPsiElement(QUTE_TEXT)
+      PsiElement(QUTE_TEXT)('!</h1>')

--- a/testData/qute/psi/FindElementAt_AlternativeSyntax_NamespacedObjectPart.txt
+++ b/testData/qute/psi/FindElementAt_AlternativeSyntax_NamespacedObjectPart.txt
@@ -1,0 +1,10 @@
+QUTE_FILE
+  ASTWrapperPsiElement(QuteElementType.QUTE_CONTENT)
+    ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION)
+      PsiElement(QuteElementType.QUTE_START_EXPRESSION)('{=')
+      ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION_NAMESPACE_PART)
+        PsiElement(QuteElementType.QUTE_EXPRESSION_NAMESPACE_PART)('uri')
+      PsiElement(QuteElementType.QUTE_EXPRESSION_COLON_SPACE)(':')
+      ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION_OBJECT_PART)
+        PsiElement(QuteElementType.QUTE_EXPRESSION_OBJECT_PART)('item')
+      PsiElement(QuteElementType.QUTE_END_EXPRESSION)('}')

--- a/testData/qute/psi/FindElementAt_AlternativeSyntax_PropertyPart.txt
+++ b/testData/qute/psi/FindElementAt_AlternativeSyntax_PropertyPart.txt
@@ -1,0 +1,10 @@
+QUTE_FILE
+  ASTWrapperPsiElement(QuteElementType.QUTE_CONTENT)
+    ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION)
+      PsiElement(QuteElementType.QUTE_START_EXPRESSION)('{=')
+      ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION_OBJECT_PART)
+        PsiElement(QuteElementType.QUTE_EXPRESSION_OBJECT_PART)('item')
+      PsiElement(QuteElementType.QUTE_EXPRESSION_DOT)('.')
+      ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION_PROPERTY_PART)
+        PsiElement(QuteElementType.QUTE_EXPRESSION_PROPERTY_PART)('name')
+      PsiElement(QuteElementType.QUTE_END_EXPRESSION)('}')

--- a/testData/qute/psi/FindElementAt_AlternativeSyntax_SimpleObjectPart.txt
+++ b/testData/qute/psi/FindElementAt_AlternativeSyntax_SimpleObjectPart.txt
@@ -1,0 +1,7 @@
+QUTE_FILE
+  ASTWrapperPsiElement(QuteElementType.QUTE_CONTENT)
+    ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION)
+      PsiElement(QuteElementType.QUTE_START_EXPRESSION)('{=')
+      ASTWrapperPsiElement(QuteElementType.QUTE_EXPRESSION_OBJECT_PART)
+        PsiElement(QuteElementType.QUTE_EXPRESSION_OBJECT_PART)('item')
+      PsiElement(QuteElementType.QUTE_END_EXPRESSION)('}')


### PR DESCRIPTION
feat: Qute Syntax coloration for alt syntax expression

This PR fixes 

 * syntax coloration with alt
 * Ctrl+Click to select the proper range. It is working only when alt is configured in application.properties but not when .qute file is used since when QuteLexer is created we don't know the file and we cannot search the folder parent which contains .qute file.

Here a demo:

<img width="939" height="488" alt="AltExprSyntaxDemo2" src="https://github.com/user-attachments/assets/ca52ccbc-1beb-4cc8-8292-d8c891bea377" />

