### PR TITLE
fix: replace Internal PluginManagerCore.getPlugin (since 2026.2 eap) with Manager.getInstance().findEnabledPlugin

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusServer.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/lsp/QuarkusServer.java
@@ -12,7 +12,7 @@ package com.redhat.devtools.intellij.quarkus.lsp;
 
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -22,6 +22,7 @@ import com.redhat.devtools.lsp4ij.server.JavaProcessCommandBuilder;
 import com.redhat.devtools.lsp4ij.server.OSProcessStreamConnectionProvider;
 import com.redhat.devtools.lsp4ij.server.ProcessStreamConnectionProvider;
 import com.redhat.devtools.intellij.lsp4mp4ij.settings.UserDefinedMicroProfileSettings;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,11 +38,11 @@ import java.util.Map;
  */
 public class QuarkusServer extends OSProcessStreamConnectionProvider {
 
-    private final Project project;
+    private final @NotNull Project project;
 
-    public QuarkusServer(Project project) {
+    public QuarkusServer(@NotNull Project project) {
         this.project = project;
-        IdeaPluginDescriptor descriptor = PluginManagerCore.getPlugin(PluginId.getId("com.redhat.devtools.intellij.quarkus"));
+        IdeaPluginDescriptor descriptor = PluginManager.getInstance().findEnabledPlugin(PluginId.getId("com.redhat.devtools.intellij.quarkus"));
         assert descriptor != null;
         Path pluginPath = descriptor.getPluginPath();
         assert pluginPath != null;

--- a/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteServer.java
+++ b/src/main/java/com/redhat/devtools/intellij/qute/lsp/QuteServer.java
@@ -12,7 +12,7 @@ package com.redhat.devtools.intellij.qute.lsp;
 
 import com.intellij.execution.configurations.GeneralCommandLine;
 import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManagerCore;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -24,6 +24,7 @@ import com.redhat.devtools.lsp4ij.server.OSProcessStreamConnectionProvider;
 import com.redhat.devtools.lsp4ij.server.ProcessStreamConnectionProvider;
 import com.redhat.devtools.intellij.qute.settings.UserDefinedQuteSettings;
 import com.redhat.qute.services.commands.QuteClientCommandConstants;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,11 +39,11 @@ import java.util.Map;
  */
 public class QuteServer extends OSProcessStreamConnectionProvider {
 
-    private final Project project;
+    private final @NotNull Project project;
 
-    public QuteServer(Project project) {
+    public QuteServer(@NotNull Project project) {
         this.project = project;
-        IdeaPluginDescriptor descriptor = PluginManagerCore.getPlugin(PluginId.getId("com.redhat.devtools.intellij.quarkus"));
+        IdeaPluginDescriptor descriptor = PluginManager.getInstance().findEnabledPlugin(PluginId.getId("com.redhat.devtools.intellij.quarkus"));
         assert descriptor != null;
         Path pluginPath = descriptor.getPluginPath();
         assert pluginPath != null;


### PR DESCRIPTION
fix: replace Internal PluginManagerCore.getPlugin (since 2026.2 eap) with Manager.getInstance().findEnabledPlugin