### PR TITLE
fix: Add Support of Gradle 9

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/AbstractGradleToolDelegate.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/AbstractGradleToolDelegate.java
@@ -80,9 +80,15 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
      * only relies on the DSL agnostic Gradle project API. This replaces the legacy approach based on a custom
      * settings file (selected with the {@code -c} option) and {@code rootProject.buildFileName}, both removed
      * in Gradle 9.
+     * <p>
+     * The configuration/dependencies/task are contributed to the project whose directory matches the analyzed
+     * module directory (not necessarily the root project), so the deployment artifacts are resolved with that
+     * module's own repositories. This keeps multi-module projects working, where repositories may be declared
+     * per subproject.
      * <ul>
      *     <li>{@code %1$s} is the list of deployment dependencies to resolve</li>
      *     <li>{@code %2$s} is the path of the file where the resolved artifacts are written</li>
+     *     <li>{@code %3$s} is the directory of the analyzed module (used to select the target Gradle project)</li>
      * </ul>
      */
     private static final String INIT_SCRIPT_TEMPLATE = """
@@ -91,7 +97,7 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
             import org.gradle.api.artifacts.result.ResolvedArtifactResult
 
             allprojects { proj ->
-                if (proj == proj.rootProject) {
+                if (proj.projectDir.canonicalPath == new File('%3$s').canonicalPath) {
                     proj.afterEvaluate { project ->
                         project.configurations.create('quarkusDeployment')
             %1$s\
@@ -172,7 +178,7 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
                                  @NotNull Set<String> deploymentIds,
                                  @NotNull List<VirtualFile>[] result) throws IOException {
         Path outputPath = Files.createTempFile(null, ".txt");
-        Path initScript = generateInitScript(outputPath, deploymentIds);
+        Path initScript = generateInitScript(outputPath, deploymentIds, getModuleDirPath(module));
         TaskCallback callback = new TaskCallback() {
             @Override
             public void onSuccess() {
@@ -262,8 +268,8 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
      * @return the path to the generated init script
      * @throws IOException if an error occurs generating the file
      */
-    private Path generateInitScript(Path outputPath, Set<String> deploymentIds) throws IOException {
-        String content = buildInitScript(outputPath, deploymentIds);
+    private Path generateInitScript(Path outputPath, Set<String> deploymentIds, String moduleDirPath) throws IOException {
+        String content = buildInitScript(outputPath, deploymentIds, moduleDirPath);
         Path initScript = Files.createTempFile("quarkus-list-dependencies", ".gradle");
         try (Writer writer = Files.newBufferedWriter(initScript, StandardCharsets.UTF_8)) {
             IOUtils.write(content, writer);
@@ -276,17 +282,21 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
      *
      * @param outputPath    the path to the task result file
      * @param deploymentIds the Maven coordinates of the module deployment JARs
+     * @param moduleDirPath the directory of the analyzed module, used to select the target Gradle project
      * @return the content of the init script
      */
     // Package-private for testing (see GradleListQuarkusDependenciesInitScriptTest).
-    String buildInitScript(Path outputPath, Set<String> deploymentIds) {
+    String buildInitScript(Path outputPath, Set<String> deploymentIds, String moduleDirPath) {
         StringBuilder dependencies = new StringBuilder();
         deploymentIds.forEach(id ->
                 dependencies.append("                project.dependencies.add('quarkusDeployment', '")
                         .append(id)
                         .append("')")
                         .append(System.lineSeparator()));
-        return String.format(INIT_SCRIPT_TEMPLATE, dependencies.toString(), outputPath.toString().replace("\\", "\\\\"));
+        return String.format(INIT_SCRIPT_TEMPLATE,
+                dependencies.toString(),
+                outputPath.toString().replace("\\", "\\\\"),
+                moduleDirPath.replace("\\", "\\\\"));
     }
 
     private void processLibrary(Library library, ModuleRootManager manager, Set<String> deploymentIds) {

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/AbstractGradleToolDelegate.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/AbstractGradleToolDelegate.java
@@ -28,6 +28,7 @@ import com.intellij.openapi.module.ModifiableModuleModel;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleGrouper;
 import com.intellij.openapi.module.ModuleManager;
+import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectUtil;
@@ -64,6 +65,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
@@ -158,7 +161,7 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
             });
             if (!deploymentIds.isEmpty()) {
                 progressIndicator.checkCanceled();
-                processDownload(module, deploymentIds, result);
+                processDownload(module, deploymentIds, result, progressIndicator);
             }
         } catch (IOException e) {
             LOGGER.error(e.getLocalizedMessage(), e);
@@ -169,14 +172,16 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
     /**
      * Collect all deployment JARs and dependencies including the sources JARs. Will run a specific Gradle task.
      *
-     * @param module        the module
-     * @param deploymentIds the Maven coordinates of the module deployment JARs
-     * @param result        the list where to place results to
+     * @param module            the module
+     * @param deploymentIds     the Maven coordinates of the module deployment JARs
+     * @param result            the list where to place results to
+     * @param progressIndicator the progress indicator used to react to cancellation while the task runs
      * @throws IOException if an error occurs running Gradle
      */
     private void processDownload(@NotNull Module module,
                                  @NotNull Set<String> deploymentIds,
-                                 @NotNull List<VirtualFile>[] result) throws IOException {
+                                 @NotNull List<VirtualFile>[] result,
+                                 @NotNull ProgressIndicator progressIndicator) throws IOException {
         Path outputPath = Files.createTempFile(null, ".txt");
         Path initScript = generateInitScript(outputPath, deploymentIds, getModuleDirPath(module));
         TaskCallback callback = new TaskCallback() {
@@ -201,7 +206,7 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
 
         };
         try {
-            collectDependencies(module, initScript, outputPath, result, callback);
+            collectDependencies(module, initScript, outputPath, result, callback, progressIndicator);
         } catch (IOException e) {
             LOGGER.warn(e.getLocalizedMessage(), e);
         } finally {
@@ -216,27 +221,58 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
     /**
      * Collect all deployment JARs and dependencies through a Gradle specific task.
      *
-     * @param module     the module to analyze
-     * @param initScript the Gradle init script that contributes the {@code listQuarkusDependencies} task
-     * @param outputPath the file where the result of the specific task is stored
-     * @param result     the list where to place results to
-     * @param callback   the callback to call after running the task
+     * @param module            the module to analyze
+     * @param initScript        the Gradle init script that contributes the {@code listQuarkusDependencies} task
+     * @param outputPath        the file where the result of the specific task is stored
+     * @param result            the list where to place results to
+     * @param callback          the callback to call after running the task
+     * @param progressIndicator the progress indicator used to react to cancellation while the task runs
      * @throws IOException if an error occurs running Gradle
      */
     private void collectDependencies(@NotNull Module module,
                                      @NotNull Path initScript,
                                      @NotNull Path outputPath,
                                      @NotNull List<VirtualFile>[] result,
-                                     @NotNull TaskCallback callback) throws IOException {
+                                     @NotNull TaskCallback callback,
+                                     @NotNull ProgressIndicator progressIndicator) throws IOException {
         try {
             ExternalSystemTaskExecutionSettings executionSettings = new ExternalSystemTaskExecutionSettings();
             executionSettings.setExternalSystemIdString(GradleConstants.SYSTEM_ID.toString());
             executionSettings.setTaskNames(Collections.singletonList("listQuarkusDependencies"));
             executionSettings.setScriptParameters(String.format("--init-script \"%s\" -q --console plain", initScript.toString()));
             executionSettings.setExternalProjectPath(getModuleDirPath(module));
+
+            // The task is run asynchronously, so wait for it to complete before reading the result file:
+            // reading it eagerly would race with Gradle still writing it and would (silently) collect no
+            // deployment dependencies. This runs on a background thread (the model is committed later), so
+            // blocking here is safe.
+            CountDownLatch latch = new CountDownLatch(1);
+            TaskCallback waitingCallback = new TaskCallback() {
+                @Override
+                public void onSuccess() {
+                    try {
+                        callback.onSuccess();
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+
+                @Override
+                public void onFailure() {
+                    try {
+                        callback.onFailure();
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+            };
             ExternalSystemUtil.runTask(executionSettings,DefaultRunExecutor.EXECUTOR_ID,
                 module.getProject(),
-                GradleConstants.SYSTEM_ID, callback, ProgressExecutionMode.IN_BACKGROUND_ASYNC, false);
+                GradleConstants.SYSTEM_ID, waitingCallback, ProgressExecutionMode.IN_BACKGROUND_ASYNC, false);
+            while (!latch.await(100, TimeUnit.MILLISECONDS)) {
+                progressIndicator.checkCanceled();
+            }
+
             try (BufferedReader reader = Files.newBufferedReader(outputPath)) {
                 String id;
 
@@ -251,7 +287,10 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
                     }
                 }
             }
-        } catch (IOException e) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while collecting Quarkus deployment dependencies", e);
+        } catch (ProcessCanceledException | IOException e) {
             throw e;
         } catch (Exception e) {
             throw new IOException(e);

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/AbstractGradleToolDelegate.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/AbstractGradleToolDelegate.java
@@ -63,7 +63,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -72,6 +71,58 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
     private static final String M2_REPO = System.getProperty("user.home") + File.separator + ".m2" + File.separator + "repository";
 
     private static final String GRADLE_LIBRARY_PREFIX = "Gradle: ";
+
+    /**
+     * The Groovy init script that contributes the {@code quarkusDeployment} configuration, the deployment
+     * dependencies and the {@code listQuarkusDependencies} task to the (root) project.
+     * <p>
+     * It is applied through {@code --init-script} and works for both Groovy and Kotlin DSL projects since it
+     * only relies on the DSL agnostic Gradle project API. This replaces the legacy approach based on a custom
+     * settings file (selected with the {@code -c} option) and {@code rootProject.buildFileName}, both removed
+     * in Gradle 9.
+     * <ul>
+     *     <li>{@code %1$s} is the list of deployment dependencies to resolve</li>
+     *     <li>{@code %2$s} is the path of the file where the resolved artifacts are written</li>
+     * </ul>
+     */
+    private static final String INIT_SCRIPT_TEMPLATE = """
+            import org.gradle.jvm.JvmLibrary
+            import org.gradle.language.base.artifact.SourcesArtifact
+            import org.gradle.api.artifacts.result.ResolvedArtifactResult
+
+            allprojects { proj ->
+                if (proj == proj.rootProject) {
+                    proj.afterEvaluate { project ->
+                        project.configurations.create('quarkusDeployment')
+            %1$s\
+                        project.tasks.register('listQuarkusDependencies') {
+                            doLast {
+                                def quarkusDeployment = project.configurations.quarkusDeployment
+                                new File('%2$s').withPrintWriter('UTF8') { writer ->
+                                    quarkusDeployment.incoming.artifacts.each {
+                                        writer.println it.id.componentIdentifier
+                                        writer.println it.file
+                                    }
+                                    def componentIds = quarkusDeployment.incoming.resolutionResult.allDependencies.collect { it.selected.id }
+                                    def result = project.dependencies.createArtifactResolutionQuery()
+                                        .forComponents(componentIds)
+                                        .withArtifacts(JvmLibrary, SourcesArtifact)
+                                        .execute()
+                                    result.resolvedComponents.each { component ->
+                                        component.getArtifacts(SourcesArtifact).each { ar ->
+                                            if (ar instanceof ResolvedArtifactResult) {
+                                                writer.println ar.id.componentIdentifier
+                                                writer.println ar.file
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """;
 
     private boolean scriptExists(@NotNull Module module) {
         String path = getModuleDirPath(module);
@@ -121,8 +172,7 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
                                  @NotNull Set<String> deploymentIds,
                                  @NotNull List<VirtualFile>[] result) throws IOException {
         Path outputPath = Files.createTempFile(null, ".txt");
-        Path customBuildFile = generateCustomGradleBuild(getModuleDirPath(module), outputPath, deploymentIds);
-        Path customSettingsFile = generateCustomGradleSettings(getModuleDirPath(module), customBuildFile);
+        Path initScript = generateInitScript(outputPath, deploymentIds);
         TaskCallback callback = new TaskCallback() {
             @Override
             public void onSuccess() {
@@ -137,8 +187,7 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
 
             private void cleanCustomFiles() {
                 try {
-                    Files.delete(customBuildFile);
-                    Files.delete(customSettingsFile);
+                    Files.delete(initScript);
                 } catch (IOException e) {
                     LOGGER.warn(e.getLocalizedMessage(), e);
                 }
@@ -146,7 +195,7 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
 
         };
         try {
-            collectDependencies(module, customSettingsFile, outputPath, result, callback);
+            collectDependencies(module, initScript, outputPath, result, callback);
         } catch (IOException e) {
             LOGGER.warn(e.getLocalizedMessage(), e);
         } finally {
@@ -162,13 +211,14 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
      * Collect all deployment JARs and dependencies through a Gradle specific task.
      *
      * @param module     the module to analyze
+     * @param initScript the Gradle init script that contributes the {@code listQuarkusDependencies} task
      * @param outputPath the file where the result of the specific task is stored
      * @param result     the list where to place results to
      * @param callback   the callback to call after running the task
      * @throws IOException if an error occurs running Gradle
      */
     private void collectDependencies(@NotNull Module module,
-                                     @NotNull Path customSettingsFile,
+                                     @NotNull Path initScript,
                                      @NotNull Path outputPath,
                                      @NotNull List<VirtualFile>[] result,
                                      @NotNull TaskCallback callback) throws IOException {
@@ -176,7 +226,7 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
             ExternalSystemTaskExecutionSettings executionSettings = new ExternalSystemTaskExecutionSettings();
             executionSettings.setExternalSystemIdString(GradleConstants.SYSTEM_ID.toString());
             executionSettings.setTaskNames(Collections.singletonList("listQuarkusDependencies"));
-            executionSettings.setScriptParameters(String.format("-c %s -q --console plain", customSettingsFile.toString()));
+            executionSettings.setScriptParameters(String.format("--init-script \"%s\" -q --console plain", initScript.toString()));
             executionSettings.setExternalProjectPath(getModuleDirPath(module));
             ExternalSystemUtil.runTask(executionSettings,DefaultRunExecutor.EXECUTOR_ID,
                 module.getProject(),
@@ -204,74 +254,39 @@ public abstract class AbstractGradleToolDelegate implements BuildToolDelegate {
 
     abstract String getScriptName();
 
-    abstract String getSettingsScriptName();
-
-    abstract String getScriptExtension();
-
-    abstract String formatQuarkusDependency(String id);
-
-    abstract String generateTask(String path);
-
-    abstract String createQuarkusConfiguration();
-
     /**
-     * Generate the custom build file from the module build file and adding the specific task.
+     * Generate the Gradle init script that contributes the {@code listQuarkusDependencies} task.
      *
-     * @param basePath      the base path where the module build file is in
      * @param outputPath    the path to the task result file
      * @param deploymentIds the Maven coordinates of the module deployment JARs
-     * @return the path to the custom build file
+     * @return the path to the generated init script
      * @throws IOException if an error occurs generating the file
      */
-    private Path generateCustomGradleBuild(String basePath, Path outputPath, Set<String> deploymentIds) throws IOException {
-        Path base = Paths.get(basePath);
-        Path path = base.resolve(getScriptName());
-        try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
-            String content = IOUtils.toString(reader);
-            content = appendQuarkusResolution(content, outputPath, deploymentIds);
-            Path customPath = Files.createTempFile(base, null, getScriptExtension());
-            try (Writer writer = Files.newBufferedWriter(customPath, StandardCharsets.UTF_8)) {
-                IOUtils.write(content, writer);
-                return customPath;
-            }
-        }
-    }
-
-    private Path generateCustomGradleSettings(String basePath, Path customBuildFile) throws IOException {
-        Path base = Paths.get(basePath);
-        Path path = base.resolve(getSettingsScriptName());
-        String content = "";
-        try (Reader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8)) {
-            content = IOUtils.toString(reader);
-        } catch (IOException e) {
-            LOGGER.warn(e.getLocalizedMessage(), e);
-        }
-        content += System.lineSeparator() + "rootProject.buildFileName =\"" + customBuildFile.getFileName().toFile().getName() + "\"";
-        Path customPath = Files.createTempFile(base, null, getScriptExtension());
-        try (Writer writer = Files.newBufferedWriter(customPath, StandardCharsets.UTF_8)) {
+    private Path generateInitScript(Path outputPath, Set<String> deploymentIds) throws IOException {
+        String content = buildInitScript(outputPath, deploymentIds);
+        Path initScript = Files.createTempFile("quarkus-list-dependencies", ".gradle");
+        try (Writer writer = Files.newBufferedWriter(initScript, StandardCharsets.UTF_8)) {
             IOUtils.write(content, writer);
-            return customPath;
+            return initScript;
         }
     }
-
 
     /**
-     * Append the specific task definition.
+     * Build the content of the init script.
      *
-     * @param content       the content of the module build file
      * @param outputPath    the path to the task result file
      * @param deploymentIds the Maven coordinates of the module deployment JARs
-     * @return the content of the custom build file
+     * @return the content of the init script
      */
-    private String appendQuarkusResolution(String content, Path outputPath, Set<String> deploymentIds) {
-        StringBuilder buffer = new StringBuilder(content);
-        buffer.append(System.lineSeparator());
-        buffer.append(createQuarkusConfiguration()).append(System.lineSeparator());
-        buffer.append("dependencies {").append(System.lineSeparator());
-        deploymentIds.forEach(id -> buffer.append(formatQuarkusDependency(id)));
-        buffer.append('}').append(System.lineSeparator());
-        buffer.append(generateTask(outputPath.toString().replace("\\", "\\\\")));
-        return buffer.toString();
+    // Package-private for testing (see GradleListQuarkusDependenciesInitScriptTest).
+    String buildInitScript(Path outputPath, Set<String> deploymentIds) {
+        StringBuilder dependencies = new StringBuilder();
+        deploymentIds.forEach(id ->
+                dependencies.append("                project.dependencies.add('quarkusDeployment', '")
+                        .append(id)
+                        .append("')")
+                        .append(System.lineSeparator()));
+        return String.format(INIT_SCRIPT_TEMPLATE, dependencies.toString(), outputPath.toString().replace("\\", "\\\\"));
     }
 
     private void processLibrary(Library library, ModuleRootManager manager, Set<String> deploymentIds) {

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/GradleGroovyToolDelegate.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/GradleGroovyToolDelegate.java
@@ -10,62 +10,11 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.quarkus.buildtool.gradle;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class GradleGroovyToolDelegate extends AbstractGradleToolDelegate {
-    private static final Logger LOGGER = LoggerFactory.getLogger(GradleGroovyToolDelegate.class);
-
-    private static final String QUARKUS_DOWNLOAD_TASK_DEFINITION =
-            "task listQuarkusDependencies() {" + System.lineSeparator() +
-                    "    File f = new File('%1$s')" + System.lineSeparator() +
-                    "    f.withPrintWriter('UTF8') { writer ->" + System.lineSeparator() +
-                    "        configurations.quarkusDeployment.incoming.artifacts.each {" + System.lineSeparator() +
-                    "            writer.println it.id.componentIdentifier" + System.lineSeparator() +
-                    "            writer.println it.file" + System.lineSeparator() +
-                    "        }" + System.lineSeparator() +
-                    "        def componentIds = configurations.quarkusDeployment.incoming.resolutionResult.allDependencies.collect { it.selected.id }" + System.lineSeparator() +
-                    "        ArtifactResolutionResult result = dependencies.createArtifactResolutionQuery()" + System.lineSeparator() +
-                    "            .forComponents(componentIds)" + System.lineSeparator() +
-                    "            .withArtifacts(JvmLibrary, SourcesArtifact)" + System.lineSeparator() +
-                    "            .execute()" + System.lineSeparator() +
-                    "        result.resolvedComponents.each { ComponentArtifactsResult component ->" + System.lineSeparator() +
-                    "            Set<ArtifactResult> sources = component.getArtifacts(SourcesArtifact)" + System.lineSeparator() +
-                    "            sources.each { ArtifactResult ar ->" + System.lineSeparator() +
-                    "                if (ar instanceof ResolvedArtifactResult) {" + System.lineSeparator() +
-                    "                    writer.println ar.id.componentIdentifier" + System.lineSeparator() +
-                    "                    writer.println ar.file" + System.lineSeparator() +
-                    "                }" + System.lineSeparator() +
-                    "            }" + System.lineSeparator() +
-                    "        }" + System.lineSeparator() +
-                    "    }" + System.lineSeparator() +
-                    "}";
 
     @Override
     String getScriptName() {
         return "build.gradle";
-    }
-
-    @Override
-    String getSettingsScriptName() {
-        return "settings.gradle";
-    }
-
-    @Override
-    String getScriptExtension() {
-        return ".gradle";
-    }
-
-    String formatQuarkusDependency(String id) {
-        return "quarkusDeployment '" + id + '\'' + System.lineSeparator();
-    }
-
-    String generateTask(String path) {
-        return String.format(QUARKUS_DOWNLOAD_TASK_DEFINITION, path);
-    }
-
-    String createQuarkusConfiguration() {
-        return "configurations {quarkusDeployment}";
     }
 
     @Override

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/GradleKotlinToolDelegate.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/GradleKotlinToolDelegate.java
@@ -10,63 +10,11 @@
  ******************************************************************************/
 package com.redhat.devtools.intellij.quarkus.buildtool.gradle;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class GradleKotlinToolDelegate extends AbstractGradleToolDelegate {
-    private static final Logger LOGGER = LoggerFactory.getLogger(GradleKotlinToolDelegate.class);
-
-    private static final String QUARKUS_DOWNLOAD_TASK_DEFINITION =
-            "typealias PrintWriter = java.io.PrintWriter" + System.lineSeparator() +
-            "typealias FileWriter = java.io.FileWriter" + System.lineSeparator() +
-            "tasks.register(\"listQuarkusDependencies\") {" + System.lineSeparator() +
-            "    val writer = PrintWriter(FileWriter(\"%1$s\"))" + System.lineSeparator() +
-            "    quarkusDeployment.incoming.artifacts.forEach {" + System.lineSeparator() +
-            "        writer.println(it.id.componentIdentifier)" + System.lineSeparator() +
-            "        writer.println(it.file)" + System.lineSeparator() +
-            "    }" + System.lineSeparator() +
-            "    val componentIds = quarkusDeployment.incoming.resolutionResult.allDependencies.map { (it as ResolvedDependencyResult).selected.id }" + System.lineSeparator() +
-            "    val result = dependencies.createArtifactResolutionQuery()" + System.lineSeparator() +
-            "        .forComponents(componentIds)" + System.lineSeparator() +
-            "        .withArtifacts(JvmLibrary::class, SourcesArtifact::class)" + System.lineSeparator() +
-		    "        .execute()" + System.lineSeparator() +
-            "    result.resolvedComponents.forEach { component ->" + System.lineSeparator() +
-            "        val sources = component.getArtifacts(SourcesArtifact::class)" + System.lineSeparator() +
-            "        sources.forEach { ar ->" + System.lineSeparator() +
-            "            if (ar is ResolvedArtifactResult) {" + System.lineSeparator() +
-            "                writer.println(ar.id.componentIdentifier)" + System.lineSeparator() +
-            "                writer.println(ar.file)" + System.lineSeparator() +
-            "            }" + System.lineSeparator() +
-            "        }" + System.lineSeparator() +
-            "    }" + System.lineSeparator() +
-            "    writer.close()" + System.lineSeparator() +
-            "}";
 
     @Override
     String getScriptName() {
         return "build.gradle.kts";
-    }
-
-    @Override
-    String getSettingsScriptName() {
-        return "settings.gradle.kts";
-    }
-
-    @Override
-    String getScriptExtension() {
-        return ".gradle.kts";
-    }
-
-    String formatQuarkusDependency(String id) {
-        return "quarkusDeployment(\"" + id + "\")" + System.lineSeparator();
-    }
-
-    String generateTask(String path) {
-        return String.format(QUARKUS_DOWNLOAD_TASK_DEFINITION, path);
-    }
-
-    String createQuarkusConfiguration() {
-        return "val quarkusDeployment by configurations.creating";
     }
 
     @Override

--- a/src/test/java/com/redhat/devtools/intellij/GradleTestCase.java
+++ b/src/test/java/com/redhat/devtools/intellij/GradleTestCase.java
@@ -71,6 +71,11 @@ public abstract class GradleTestCase extends GradleImportingTestCase {
 
     @Parameterized.Parameters(name = "{index}: with Gradle-{0}")
     public static Collection<Object[]> data() {
+        // These integration tests import fixtures that apply the Quarkus Gradle plugin. The plugin
+        // versions pinned by those fixtures (1.x/2.x) predate Gradle 9 support and fail to configure
+        // on Gradle 9 (e.g. the removed JavaPluginConvention), so the suite is kept on Gradle 8.x.
+        // Gradle 9 compatibility of the deployment-collection init script is covered, without the
+        // Quarkus plugin, by GradleListQuarkusDependenciesInitScriptTest.
         return Arrays.asList(new Object[][]{{"8.6"}});
     }
 

--- a/src/test/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/GradleListQuarkusDependenciesInitScriptTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/GradleListQuarkusDependenciesInitScriptTest.java
@@ -35,10 +35,10 @@ import static org.junit.Assert.assertTrue;
  * where the {@code -c}/{@code --settings-file} option and {@code rootProject.buildFileName} that the
  * previous implementation relied on were removed.
  * <p>
- * This test intentionally does <b>not</b> apply the Quarkus Gradle plugin: the plugin versions pinned
+ * These tests intentionally do <b>not</b> apply the Quarkus Gradle plugin: the plugin versions pinned
  * by the other Gradle test fixtures (1.x/2.x) are not Gradle 9 compatible and would mask whether the
- * init-script mechanism itself works. Instead it drives a minimal {@code java} project through the
- * Tooling API with the real init script and asserts that both the binary and the sources artifacts of
+ * init-script mechanism itself works. Instead they drive minimal {@code java} projects through the
+ * Tooling API with the real init script and assert that both the binary and the sources artifacts of
  * a deployment dependency are resolved and written in the format the delegate expects.
  *
  * @see <a href="https://github.com/redhat-developer/intellij-quarkus/issues/1512">redhat-developer/intellij-quarkus#1512</a>
@@ -61,19 +61,61 @@ public class GradleListQuarkusDependenciesInitScriptTest {
     @Parameterized.Parameter
     public String gradleVersion;
 
+    /**
+     * Single-module project: the analyzed module is the root project.
+     */
     @Test
-    public void resolvesDeploymentArtifactsViaInitScript() throws Exception {
-        Path projectDir = Files.createTempDirectory("quarkus-init-it");
-        Path outputPath = Files.createTempFile("quarkus-deps", ".txt");
-        Path initScriptFile = Files.createTempFile("quarkus-init", ".gradle");
+    public void resolvesDeploymentArtifactsForSingleModuleProject() throws Exception {
+        Path projectDir = Files.createTempDirectory("quarkus-init-single");
         try {
-            Files.writeString(projectDir.resolve("settings.gradle"), "rootProject.name = 'init-script-it'\n");
+            Files.writeString(projectDir.resolve("settings.gradle"), "rootProject.name = 'single-module'\n");
             Files.writeString(projectDir.resolve("build.gradle"),
                     "plugins { id 'java' }\n" +
                     "repositories { mavenCentral() }\n");
 
+            runAndAssert(projectDir, projectDir);
+        } finally {
+            deleteRecursively(projectDir);
+        }
+    }
+
+    /**
+     * Multi-module project: the analyzed module is a subproject, and the repositories needed to resolve
+     * the deployment artifacts are declared <b>only</b> in that subproject (not in the root). This fails
+     * if the init script attaches the {@code quarkusDeployment} configuration to the root project instead
+     * of the analyzed module.
+     */
+    @Test
+    public void resolvesDeploymentArtifactsForSubProjectWithOwnRepositories() throws Exception {
+        Path rootDir = Files.createTempDirectory("quarkus-init-multi");
+        try {
+            Files.writeString(rootDir.resolve("settings.gradle"),
+                    "rootProject.name = 'multi-module'\n" +
+                    "include 'app'\n");
+            // Root has no repositories on purpose.
+            Files.writeString(rootDir.resolve("build.gradle"), "");
+
+            Path appDir = Files.createDirectories(rootDir.resolve("app"));
+            Files.writeString(appDir.resolve("build.gradle"),
+                    "plugins { id 'java' }\n" +
+                    "repositories { mavenCentral() }\n");
+
+            runAndAssert(rootDir, appDir);
+        } finally {
+            deleteRecursively(rootDir);
+        }
+    }
+
+    /**
+     * Generate the real init script for {@code moduleDir}, run {@code listQuarkusDependencies} from
+     * {@code projectDir} on the parameterized Gradle version, and assert both jars are resolved.
+     */
+    private void runAndAssert(Path projectDir, Path moduleDir) throws Exception {
+        Path outputPath = Files.createTempFile("quarkus-deps", ".txt");
+        Path initScriptFile = Files.createTempFile("quarkus-init", ".gradle");
+        try {
             String initScript = new GradleGroovyToolDelegate()
-                    .buildInitScript(outputPath, Collections.singleton(DEPLOYMENT_ID));
+                    .buildInitScript(outputPath, Collections.singleton(DEPLOYMENT_ID), moduleDir.toString());
             Files.writeString(initScriptFile, initScript);
 
             try (ProjectConnection connection = GradleConnector.newConnector()
@@ -96,7 +138,6 @@ public class GradleListQuarkusDependenciesInitScriptTest {
         } finally {
             Files.deleteIfExists(initScriptFile);
             Files.deleteIfExists(outputPath);
-            deleteRecursively(projectDir);
         }
     }
 

--- a/src/test/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/GradleListQuarkusDependenciesInitScriptTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/GradleListQuarkusDependenciesInitScriptTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution,
+ * and is available at https://www.eclipse.org/legal/epl-v20.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package com.redhat.devtools.intellij.quarkus.buildtool.gradle;
+
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProjectConnection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Verifies the Gradle init script used by {@link AbstractGradleToolDelegate} to collect Quarkus
+ * deployment dependencies (the {@code listQuarkusDependencies} task) actually runs on Gradle 9,
+ * where the {@code -c}/{@code --settings-file} option and {@code rootProject.buildFileName} that the
+ * previous implementation relied on were removed.
+ * <p>
+ * This test intentionally does <b>not</b> apply the Quarkus Gradle plugin: the plugin versions pinned
+ * by the other Gradle test fixtures (1.x/2.x) are not Gradle 9 compatible and would mask whether the
+ * init-script mechanism itself works. Instead it drives a minimal {@code java} project through the
+ * Tooling API with the real init script and asserts that both the binary and the sources artifacts of
+ * a deployment dependency are resolved and written in the format the delegate expects.
+ *
+ * @see <a href="https://github.com/redhat-developer/intellij-quarkus/issues/1512">redhat-developer/intellij-quarkus#1512</a>
+ */
+@RunWith(Parameterized.class)
+public class GradleListQuarkusDependenciesInitScriptTest {
+
+    // commons-lang3 publishes a -sources.jar, so both the binary and sources resolution paths are covered.
+    private static final String DEPLOYMENT_ID = "org.apache.commons:commons-lang3:3.14.0";
+    private static final String BINARY_JAR = "commons-lang3-3.14.0.jar";
+    private static final String SOURCES_JAR = "commons-lang3-3.14.0-sources.jar";
+
+    @Parameterized.Parameters(name = "Gradle {0}")
+    public static Collection<String> gradleVersions() {
+        // 8.6 is the version the rest of the suite uses (regression guard); 9.6.0 is the version that
+        // dropped the -c option this fix is about.
+        return Arrays.asList("8.6", "9.6.0");
+    }
+
+    @Parameterized.Parameter
+    public String gradleVersion;
+
+    @Test
+    public void resolvesDeploymentArtifactsViaInitScript() throws Exception {
+        Path projectDir = Files.createTempDirectory("quarkus-init-it");
+        Path outputPath = Files.createTempFile("quarkus-deps", ".txt");
+        Path initScriptFile = Files.createTempFile("quarkus-init", ".gradle");
+        try {
+            Files.writeString(projectDir.resolve("settings.gradle"), "rootProject.name = 'init-script-it'\n");
+            Files.writeString(projectDir.resolve("build.gradle"),
+                    "plugins { id 'java' }\n" +
+                    "repositories { mavenCentral() }\n");
+
+            String initScript = new GradleGroovyToolDelegate()
+                    .buildInitScript(outputPath, Collections.singleton(DEPLOYMENT_ID));
+            Files.writeString(initScriptFile, initScript);
+
+            try (ProjectConnection connection = GradleConnector.newConnector()
+                    .forProjectDirectory(projectDir.toFile())
+                    .useGradleVersion(gradleVersion)
+                    .connect()) {
+                connection.newBuild()
+                        .forTasks("listQuarkusDependencies")
+                        .withArguments("--init-script", initScriptFile.toString(), "-q")
+                        .run();
+            }
+
+            List<String> lines = Files.readAllLines(outputPath, StandardCharsets.UTF_8);
+            assertTrue("listQuarkusDependencies produced no usable output on Gradle " + gradleVersion + ": " + lines,
+                    lines.size() >= 4);
+            assertTrue("Binary jar not resolved on Gradle " + gradleVersion + ": " + lines,
+                    lines.stream().anyMatch(line -> line.endsWith(BINARY_JAR)));
+            assertTrue("Sources jar not resolved on Gradle " + gradleVersion + ": " + lines,
+                    lines.stream().anyMatch(line -> line.endsWith(SOURCES_JAR)));
+        } finally {
+            Files.deleteIfExists(initScriptFile);
+            Files.deleteIfExists(outputPath);
+            deleteRecursively(projectDir);
+        }
+    }
+
+    private static void deleteRecursively(Path dir) throws IOException {
+        if (Files.exists(dir)) {
+            try (Stream<Path> paths = Files.walk(dir)) {
+                paths.sorted(Comparator.reverseOrder()).forEach(path -> path.toFile().delete());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Since Gradle 9, the extension fails to collect Quarkus deployment dependencies: it runs `listQuarkusDependencies -c <settingsFile>`, but the `-c` / `--settings-file` option (and the `rootProject.buildFileName` property it relied on) were **removed in Gradle 9**. As a result the task never launches and the Quarkus deployment JARs are not added to the module classpath. Works on Gradle 8, broken on Gradle 9.

Fixes redhat-developer/intellij-quarkus#1512

## Root cause

`AbstractGradleToolDelegate` generated a **custom build file** (a copy of the project build script + an appended task) and a **custom settings file** (with `rootProject.buildFileName = …`), then selected them with `-c <settingsFile>`. Gradle 9 removed:

- the `-c` / `--settings-file` (and `-b` / `--build-file`) command-line options, and
- `rootProject.buildFileName`.

## Fix

Collect the deployment dependencies through a Gradle **init script** (`--init-script`) instead, which is supported by both Gradle 8 and Gradle 9.

- The init script contributes the `quarkusDeployment` configuration, the deployment dependencies and the `listQuarkusDependencies` task to the project in an `afterEvaluate` hook.
- It no longer copies or modifies the user's `build.gradle(.kts)` / `settings.gradle(.kts)` — the project's own repositories are used to resolve the deployment artifacts.
- A single **Groovy** init script works for both Groovy and Kotlin DSL projects because it only uses the DSL-agnostic Gradle project API. As a result, `GradleGroovyToolDelegate` and `GradleKotlinToolDelegate` collapse to plain DSL (build-script name) detection.

## Tests

Adding `9.6.0` to the existing `GradleTestCase` parameter set is **not** a valid way to validate this on Gradle 9: every Gradle fixture applies the Quarkus Gradle plugin, and the plugin versions those fixtures pin (1.x/2.x) cannot configure on Gradle 9 themselves (e.g. the removed `JavaPluginConvention`, and an `integrationTestImplementation` configuration conflict). The project fails before `listQuarkusDependencies` ever runs, so the result would be a false signal — unrelated to this fix.

Instead:

- The integration-test suite stays on Gradle 8.x, with a comment in `GradleTestCase.data()` explaining why.
- A focused, **plugin-free** test, `GradleListQuarkusDependenciesInitScriptTest`, drives the real init script through the Gradle Tooling API on both **Gradle 8.6 and 9.6.0** and asserts that a deployment dependency's **binary and sources** JARs are resolved in the exact format the delegate parses.

| Check | Gradle 8.6 | Gradle 9.6.0 |
|---|---|---|
| `GradleListQuarkusDependenciesInitScriptTest` (binary + sources resolution) | ✅ | ✅ |
| `GradleQuarkusLibraryTest` (runs `listQuarkusDependencies` end-to-end) | ✅ | n/a (fixture plugin not Gradle 9 compatible) |

## Notes / follow-ups

- Running the full integration-test suite on Gradle 9 will require modernizing the Gradle fixtures to a Quarkus 3.x version that supports Gradle 9. That's a larger, separate change and is out of scope here.

## Changes

- `AbstractGradleToolDelegate`: generate and run a Gradle init script (`--init-script`); remove the custom build/settings-file generation and the now-unused abstract methods.
- `GradleGroovyToolDelegate` / `GradleKotlinToolDelegate`: reduce to build-script name + display metadata.
- `GradleTestCase`: keep the suite on Gradle 8.6, with an explanatory comment.
- New `GradleListQuarkusDependenciesInitScriptTest`: Gradle 9 (and 8) regression test for the init-script mechanism.