### PR TITLE
fix: Avoid duplicate Quarkus config property metadata

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/core/PropertiesCollector.java
+++ b/src/main/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/core/PropertiesCollector.java
@@ -15,9 +15,11 @@ package com.redhat.devtools.intellij.lsp4mp4ij.psi.internal.core;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import com.redhat.devtools.intellij.lsp4mp4ij.psi.core.IPropertiesCollector;
 import org.eclipse.lsp4mp.commons.MicroProfilePropertiesScope;
@@ -38,6 +40,12 @@ public class PropertiesCollector implements IPropertiesCollector {
 
 	private final Map<String, ItemHint> hintsCache;
 
+	/**
+	 * Keys of the properties already collected, used to avoid contributing the same property twice for
+	 * the same source member.
+	 */
+	private final Set<String> propertyKeys;
+
 	private final boolean onlySources;
 
 	public PropertiesCollector(ConfigurationMetadata configuration, List<MicroProfilePropertiesScope> scopes) {
@@ -45,6 +53,7 @@ public class PropertiesCollector implements IPropertiesCollector {
 		this.configuration.setProperties(new ArrayList<>());
 		this.configuration.setHints(new ArrayList<>());
 		this.hintsCache = new HashMap<>();
+		this.propertyKeys = new HashSet<>();
 		this.onlySources = MicroProfilePropertiesScope.isOnlySources(scopes);
 	}
 
@@ -70,8 +79,18 @@ public class PropertiesCollector implements IPropertiesCollector {
 		property.setPhase(phase);
 		property.setRequired(defaultValue == null);
 
-		configuration.getProperties().add(property);
+		// Avoid contributing the same property twice for the same source member. This happens when a config
+		// interface is annotated with both @ConfigRoot and @ConfigMapping (typical of build-time Quarkus
+		// extensions, e.g. SwaggerUiConfig): it is matched by several providers and would otherwise produce
+		// duplicate metadata, surfacing as multiple identical "Go to definition" targets.
+		if (propertyKeys.add(propertyKey(name, sourceType, sourceField, sourceMethod))) {
+			configuration.getProperties().add(property);
+		}
 		return property;
+	}
+
+	private static String propertyKey(String name, String sourceType, String sourceField, String sourceMethod) {
+		return name + ' ' + sourceType + ' ' + sourceField + ' ' + sourceMethod;
 	}
 
 	@Override

--- a/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/core/PropertiesCollectorTest.java
+++ b/src/test/java/com/redhat/devtools/intellij/lsp4mp4ij/psi/internal/core/PropertiesCollectorTest.java
@@ -106,6 +106,56 @@ public class PropertiesCollectorTest {
 		assertNull(configuration.getProperties().get(0).getDescription());
 	}
 
+	// ------------ Test with addItemMetadata de-duplication
+
+	private static final String SWAGGER_UI_CONFIG = "io.quarkus.swaggerui.deployment.SwaggerUiConfig";
+	private static final String OPTIONAL_STRING = "java.util.Optional<java.lang.String>";
+
+	@Test
+	public void addItemMetadataIgnoresDuplicateForSameSourceMember() {
+		// A config interface annotated with both @ConfigRoot and @ConfigMapping is matched by several
+		// providers, which would otherwise contribute the same property twice (and surface as multiple
+		// identical "Go to definition" targets).
+		ConfigurationMetadata configuration = new ConfigurationMetadata();
+		PropertiesCollector collector = new PropertiesCollector(configuration,
+				MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES);
+
+		collector.addItemMetadata("quarkus.swagger-ui.oauth-client-id", OPTIONAL_STRING, null,
+				SWAGGER_UI_CONFIG, null, "oauthClientId", null, "swagger-ui", true, 1);
+		collector.addItemMetadata("quarkus.swagger-ui.oauth-client-id", OPTIONAL_STRING, null,
+				SWAGGER_UI_CONFIG, null, "oauthClientId", null, "swagger-ui", true, 1);
+
+		assertEquals(1, configuration.getProperties().size());
+	}
+
+	@Test
+	public void addItemMetadataKeepsDistinctPropertiesFromSameType() {
+		ConfigurationMetadata configuration = new ConfigurationMetadata();
+		PropertiesCollector collector = new PropertiesCollector(configuration,
+				MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES);
+
+		collector.addItemMetadata("quarkus.swagger-ui.oauth-client-id", OPTIONAL_STRING, null,
+				SWAGGER_UI_CONFIG, null, "oauthClientId", null, "swagger-ui", true, 1);
+		collector.addItemMetadata("quarkus.swagger-ui.oauth-client-secret", OPTIONAL_STRING, null,
+				SWAGGER_UI_CONFIG, null, "oauthClientSecret", null, "swagger-ui", true, 1);
+
+		assertEquals(2, configuration.getProperties().size());
+	}
+
+	@Test
+	public void addItemMetadataKeepsSameNameFromDifferentSourceMembers() {
+		ConfigurationMetadata configuration = new ConfigurationMetadata();
+		PropertiesCollector collector = new PropertiesCollector(configuration,
+				MicroProfilePropertiesScope.SOURCES_AND_DEPENDENCIES);
+
+		collector.addItemMetadata("quarkus.config.value", OPTIONAL_STRING, null,
+				"com.acme.ConfigA", null, "value", null, "acme", true, 1);
+		collector.addItemMetadata("quarkus.config.value", OPTIONAL_STRING, null,
+				"com.acme.ConfigB", null, "value", null, "acme", true, 1);
+
+		assertEquals(2, configuration.getProperties().size());
+	}
+
 	private static ConfigurationMetadata createToMerge() {
 		ConfigurationMetadata toMerge = new ConfigurationMetadata();
 		toMerge.setProperties(new ArrayList<>());


### PR DESCRIPTION
## Summary

Some Quarkus config properties are contributed to the metadata **twice**, which surfaces in the IDE as a "Go to definition" chooser with two identical targets (same file, same line) instead of navigating directly. It affects some config keys such as `quarkus.swagger-ui.oauth-client-id`, while other keys (e.g. `quarkus.oidc-client.discovery-enabled`) navigate fine.

<img width="963" height="164" alt="aa" src="https://github.com/user-attachments/assets/bcb0e770-e538-4770-a071-2d95d7d11239" />

## Root cause

Some Quarkus config classes (e.g. `io.quarkus.swaggerui.deployment.SwaggerUiConfig`) are interfaces annotated with **both** `@ConfigRoot` and `@ConfigMapping`:

```java
@ConfigRoot
@ConfigMapping(prefix = "quarkus.swagger-ui")
public interface SwaggerUiConfig {
    Optional<String> oauthClientId();
    // ...
}
```

In `PropertiesManager`, the search query merges every provider's pattern, so such a class is matched by **both** the `@ConfigRoot` search (`QuarkusConfigRootProvider`) and the `@ConfigMapping` search (`QuarkusConfigMappingProvider`) and ends up being processed more than once. `PropertiesCollector.addItemMetadata` appended **every** contribution unconditionally, so the same property was added twice with identical `(name, sourceType, sourceField, sourceMethod)`.

This is exactly why only *some* properties duplicate: modern build-time configs use the `@ConfigRoot @ConfigMapping` interface style (matched by two providers), whereas many runtime configs carry only one of the two annotations (matched once).

## Fix

`PropertiesCollector` now skips a property whose `(name, sourceType, sourceField, sourceMethod)` was already collected. This collapses true duplicates while preserving:

- distinct properties from the same type (different method), and
- the same property name coming from **different** source members (no over-merging).

The change is confined to the per-property `addItemMetadata` path; the existing `merge(...)` strategies (`IGNORE_IF_EXISTS` / `REPLACE` / `FORCE`) are untouched.

## Tests

`PropertiesCollectorTest` gains three cases:

- `addItemMetadataIgnoresDuplicateForSameSourceMember` — identical contributions collapse to one.
- `addItemMetadataKeepsDistinctPropertiesFromSameType` — different methods on the same type are both kept.
- `addItemMetadataKeepsSameNameFromDifferentSourceMembers` — same name from different source types is kept.

Existing property tests still pass (e.g. `GradleQuarkusConfigRootHibernateRestEasyTest`, `MicroProfileConfigPropertyTest`), and they assert a property exists *exactly once*, so they'd fail if the dedup dropped a legitimate entry.