### PR TITLE
fix: Argument for @NotNull parameter 'module' of BuildToolDelegate.getDelegate must not be null

### DIFF
--- a/src/main/java/com/redhat/devtools/intellij/quarkus/QuarkusDeploymentSupport.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/QuarkusDeploymentSupport.java
@@ -91,11 +91,12 @@ public class QuarkusDeploymentSupport implements ClasspathResourceChangedManager
      * @param progressIndicator the progress indicator.
      */
     public void updateClasspathWithQuarkusDeployment(Module module, ProgressIndicator progressIndicator) {
-        if (module.isDisposed())
+        if (module == null || module.isDisposed()) {
             return;
+        }
         LOGGER.info("Ensuring library to " + module.getName());
         long start = System.currentTimeMillis();
-        BuildToolDelegate toolDelegate = BuildToolDelegate.getDelegate(module);
+        BuildToolDelegate toolDelegate = module != null ? BuildToolDelegate.getDelegate(module) : null;
         if (toolDelegate != null) {
             LOGGER.info("Tool delegate found for " + module.getName());
             if (isQuarkusModule(module)) {

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/GradleRunAndDebugProgramRunner.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/gradle/GradleRunAndDebugProgramRunner.java
@@ -38,7 +38,8 @@ public class GradleRunAndDebugProgramRunner implements ProgramRunner<RunnerSetti
         // and the profile check is done by checking if QuarkusRunConfiguration wraps a Gradle run/debug configuration.
         if (profile instanceof QuarkusRunConfiguration quarkusRunConfiguration) {
             // returns true if the profile is a QuarkusRunConfiguration which wraps a Gradle configuration
-            BuildToolDelegate delegate = BuildToolDelegate.getDelegate(quarkusRunConfiguration.getModule());
+            var module = quarkusRunConfiguration.getModule();
+            BuildToolDelegate delegate = module != null ? BuildToolDelegate.getDelegate(module) : null;
             return !(delegate instanceof MavenToolDelegate);
         }
         return false;

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/maven/QuarkusMavenDebugProgramRunner.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/maven/QuarkusMavenDebugProgramRunner.java
@@ -40,7 +40,8 @@ public class QuarkusMavenDebugProgramRunner extends GenericDebuggerRunner {
         // Debugging...
         if (profile instanceof QuarkusRunConfiguration quarkusRunConfiguration) {
             // returns true if the profile is a QuarkusRunConfiguration which wraps a Maven configuration
-            BuildToolDelegate delegate = BuildToolDelegate.getDelegate(quarkusRunConfiguration.getModule());
+            var module = quarkusRunConfiguration.getModule();
+            BuildToolDelegate delegate = module != null ? BuildToolDelegate.getDelegate(module) : null;
             return (delegate instanceof MavenToolDelegate);
         }
         return false;

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/maven/QuarkusMavenRunProgramRunner.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/buildtool/maven/QuarkusMavenRunProgramRunner.java
@@ -39,7 +39,8 @@ public class QuarkusMavenRunProgramRunner extends DefaultJavaProgramRunner {
         // Running...
         if (profile instanceof QuarkusRunConfiguration quarkusRunConfiguration) {
             // returns true if the profile is a QuarkusRunConfiguration which wraps a Maven configuration
-            BuildToolDelegate delegate = BuildToolDelegate.getDelegate(quarkusRunConfiguration.getModule());
+            var module = quarkusRunConfiguration.getModule();
+            BuildToolDelegate delegate = module != null ? BuildToolDelegate.getDelegate(module) : null;
             return (delegate instanceof MavenToolDelegate);
         }
         return false;

--- a/src/main/java/com/redhat/devtools/intellij/quarkus/run/QuarkusRunConfiguration.java
+++ b/src/main/java/com/redhat/devtools/intellij/quarkus/run/QuarkusRunConfiguration.java
@@ -90,7 +90,7 @@ public class QuarkusRunConfiguration extends ModuleBasedConfiguration<RunConfigu
         if (!QuarkusModuleUtil.isQuarkusModule(module)) {
             throw new RuntimeConfigurationException("Not a Quarkus module", QUARKUS_CONFIGURATION);
         }
-        BuildToolDelegate delegate = BuildToolDelegate.getDelegate(module);
+        BuildToolDelegate delegate = module != null ? BuildToolDelegate.getDelegate(module) : null;
         if (delegate == null) {
             throw new RuntimeConfigurationException("Can't find a tool to process the module", QUARKUS_CONFIGURATION);
         }
@@ -123,7 +123,9 @@ public class QuarkusRunConfiguration extends ModuleBasedConfiguration<RunConfigu
     @Override
     public RunProfileState getState(@NotNull Executor executor, @NotNull ExecutionEnvironment environment) throws ExecutionException {
         Module module = getModule();
-
+        if (module == null) {
+            return null;
+        }
         Map<String, String> telemetryData = new HashMap<>();
         telemetryData.put("kind", executor.getId());
 


### PR DESCRIPTION
fix: Argument for @NotNull parameter 'module' of BuildToolDelegate.getDelegate must not be null

Fixes #1612