### PR TITLE
build: Use LSP4MP 0.18.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,9 +19,9 @@ platformPlugins=
 gradleVersion=8.7
 channel=nightly
 quarkusVersion=3.15.1
-lsp4mpVersion=0.17.0
-quarkusLsVersion=0.25.0-SNAPSHOT
-quteLsVersion=0.25.0-SNAPSHOT
+lsp4mpVersion=0.18.0
+quarkusLsVersion=0.26.0-SNAPSHOT
+quteLsVersion=0.26.0-SNAPSHOT
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html


### PR DESCRIPTION
Use LSP4MP 0.18.0 which migrates to LSP4J 1.0.0, fixing broken hover, completion and definition in microprofile-config.properties and application.properties